### PR TITLE
Multi-node Scanner

### DIFF
--- a/python/scannerpy/__init__.py
+++ b/python/scannerpy/__init__.py
@@ -1,3 +1,3 @@
 from common import ScannerException, DeviceType
-from database import Database
+from database import Database, start_master, start_worker
 from config import Config

--- a/python/scannerpy/config.py
+++ b/python/scannerpy/config.py
@@ -64,6 +64,7 @@ class Config(object):
                     self.worker_port = int(network['worker_port'])
 
             self.master_address = self.master_address_base + ':' + str(self.master_port)
+            self.worker_address = self.master_address_base + ':' + str(self.worker_port)
 
         except KeyError as key:
             raise ScannerException('Scanner config missing key: {}'.format(key))

--- a/python/scannerpy/database.py
+++ b/python/scannerpy/database.py
@@ -4,10 +4,14 @@ import sys
 import grpc
 import imp
 import socket
+import time
+import ipaddress
 from subprocess import Popen, PIPE
 from random import choice
 from string import ascii_uppercase
-
+from multiprocessing import Process
+from urlparse import urlparse
+# Scanner imports
 from common import *
 from profiler import Profiler
 from config import Config
@@ -16,6 +20,58 @@ from sampler import Sampler
 from collection import Collection
 from table import Table
 from column import Column
+
+
+def start_master(config=None, config_path=None, block=False):
+    """
+    TODO(wcrichto)
+    """
+    if config:
+        config = config
+    else:
+        config = Config(config_path)
+
+    # Load all protobuf types
+    import libscanner as bindings
+    db = bindings.Database(
+        config.storage_config,
+        config.db_path,
+        config.master_address_base,
+        config.master_port,
+        config.worker_port)
+    result = bindings.start_master(db)
+    if not result.success:
+        return result
+    if block:
+        bindings.wait_for_server_shutdown(db)
+    return result
+
+
+def start_worker(master_address, config=None, config_path=None, block=False):
+    """
+    TODO(wcrichto)
+    """
+    if config:
+        config = config
+    else:
+        config = Config(config_path)
+
+    # Load all protobuf types
+    m_addr, _, m_port = master_address.partition(':')
+    import libscanner as bindings
+    db = bindings.Database(
+        config.storage_config,
+        config.db_path,
+        m_addr,
+        m_port,
+        config.worker_port)
+    machine_params = bindings.default_machine_params()
+    result = bindings.start_worker(db, machine_params)
+    if not result.success:
+        return result
+    if block:
+        bindings.wait_for_server_shutdown(db)
+    return result
 
 
 class Database:
@@ -28,7 +84,8 @@ class Database:
         protobufs: TODO(wcrichto)
     """
 
-    def __init__(self, config_path=None, config=None):
+    def __init__(self, master=None, workers=None,
+                 config_path=None, config=None):
         """
         Initializes a Scanner database.
 
@@ -61,21 +118,16 @@ class Database:
         # Setup database metadata
         self._db_path = self.config.db_path
         self._storage = self.config.storage
-        self._master_address = self.config.master_address
         self._cached_db_metadata = None
         self._png_dump_prefix = '__png_dump_'
 
         self.ops = OpGenerator(self)
         self.protobufs = ProtobufGenerator(self)
 
+        self.start_cluster(master, workers)
+
         # Initialize database if it does not exist
         pydb_path = '{}/pydb'.format(self._db_path)
-        self._db = self._bindings.Database(
-            self.config.storage_config,
-            self._db_path,
-            self._master_address,
-            str(self.config.master_port),
-            str(self.config.worker_port))
         if not os.path.isdir(pydb_path):
             os.mkdir(pydb_path)
             self._collections = self.protobufs.CollectionsDescriptor()
@@ -86,11 +138,8 @@ class Database:
             self.protobufs.CollectionsDescriptor,
             'pydb/descriptor.bin')
 
-        self._connect_to_master()
-
-        stdlib_path = '{}/build/stdlib'.format(self.config.module_dir)
-        self.load_op('{}/libstdlib.so'.format(stdlib_path),
-                     '{}/stdlib_pb2.py'.format(stdlib_path))
+    def __del__(self):
+        self.stop_cluster()
 
     def get_build_flags(self):
         """
@@ -186,49 +235,25 @@ class Database:
             self._master_address,
             options=[('grpc.max_message_length', 24499183 * 2)])
         self._master = self.protobufs.MasterStub(channel)
-
-        # Ping master and start master/worker locally if they don't exist.
+        result = False
         try:
             self._master.Ping(self.protobufs.Empty())
+            result = True
         except grpc.RpcError as e:
             status = e.code()
             if status == grpc.StatusCode.UNAVAILABLE:
-                log.info("Master not started, creating temporary master/worker...")
-                # If they get GC'd then the masters/workers will die, so persist
-                # them until the database object dies
-                self.start_master()
-                self.start_worker()
-                log.info("Temporary master/worker started")
-
-                # If we don't reconnect to master, there's a 5-10 sec delay for
-                # for original connection to reboot
-                channel = grpc.insecure_channel(self._master_address)
-                self._master = self.protobufs.MasterStub(channel)
-            elif status == grpc.StatusCode.OK:
                 pass
+            elif status == grpc.StatusCode.OK:
+                result = True
             else:
                 raise ScannerException('Master ping errored with status: {}'
                                        .format(status))
-
-
-    def start_master(self):
-        """
-        TODO(wcrichto)
-        """
-
-        return self._bindings.start_master(self._db)
-
-    def start_worker(self):
-        """
-        TODO(wcrichto)
-        """
-
-        machine_params = self._bindings.default_machine_params()
-        return self._bindings.start_worker(self._db, machine_params)
+        return result
 
     def _run_remote_cmd(self, host, cmd):
-        local_ip = socket.gethostbyname(socket.gethostname())
-        if socket.gethostbyname(host) == local_ip:
+        host_ip, _, _ = host.partition(':')
+        host_ip = unicode(socket.gethostbyname(host_ip), "utf-8")
+        if ipaddress.ip_address(host_ip).is_private:
             return Popen(cmd, shell=True)
         else:
             print "ssh {} {}".format(host, cmd)
@@ -244,14 +269,87 @@ class Database:
             master: ssh-able address of the master node.
             workers: list of ssh-able addresses of the worker nodes.
         """
-        master_cmd = 'python -c "from scannerpy import Database as Db; Db().start_master()"'
-        worker_cmd = 'python -c "from scannerpy import Database as Db; Db().start_worker()"'
 
-        master = self._run_remote_cmd(master, master_cmd)
-        workers = [self._run_remote_cmd(w, worker_cmd) for w in workers]
-        master.wait()
-        for worker in workers:
-            worker.wait()
+        if master is None:
+            self._master_address = self.config.master_address
+        else:
+            self._master_address = master
+        if workers is None:
+            self._worker_addresses = [self.config.worker_address]
+        else:
+            self._worker_addresses = workers
+
+        master_cmd = ('python -c ' +
+                      '"from scannerpy import start_master\n' +
+                      'start_master(block=True)"')
+        worker_cmd = ('python -c ' +
+                      '"from scannerpy import start_worker\n' +
+                      'start_worker(\'{:s}\', block=True)"').format(
+                          self._master_address)
+
+        self._master_conn = self._run_remote_cmd(self._master_address,
+                                                 master_cmd)
+        # Wait for master to start
+        slept_so_far = 0
+        sleep_time = 20
+        while slept_so_far < sleep_time:
+            if self._connect_to_master():
+                break
+            time.sleep(0.3)
+            slept_so_far += 0.3
+        if slept_so_far >= sleep_time:
+            self._master_conn.kill()
+            self._master_conn = None
+            raise ScannerException('Timed out waiting to connect to master')
+
+        # Recreate db to connect to new master
+        self._db = self._bindings.Database(
+            self.config.storage_config,
+            self._db_path,
+            self._master_address,
+            self.config.master_port,
+            self.config.worker_port)
+
+        # Start workers now that master is ready
+        self._worker_conns = [self._run_remote_cmd(w, worker_cmd)
+                              for w in self._worker_addresses]
+        slept_so_far = 0
+        sleep_time = 20
+        while slept_so_far < sleep_time:
+            active_workers = self._master.ActiveWorkers(self.protobufs.Empty())
+            if (len(active_workers.workers) > len(self._worker_addresses)):
+                raise ScannerException(
+                    ('Master has more workers than requested ' +
+                     '({:d} vs {:d})').format(len(active_workers.workers),
+                                              len(self._worker_addresses)))
+            if (len(active_workers.workers) == len(self._worker_addresses)):
+                break
+            time.sleep(0.3)
+            slept_so_far += 0.3
+        if slept_so_far >= sleep_time:
+            self._master_conn.wait()
+            for wc in self._worker_conns:
+                wc.wait()
+            self._master_conn = None
+            self._worker_conns = None
+            raise ScannerException(
+                'Timed out waiting for workers to connect to master')
+
+        # Load stdlib
+        stdlib_path = '{}/build/stdlib'.format(self.config.module_dir)
+        self.load_op('{}/libstdlib.so'.format(stdlib_path),
+                     '{}/stdlib_pb2.py'.format(stdlib_path))
+
+    def stop_cluster(self):
+        if self._master:
+            self._try_rpc(
+                lambda: self._master.Shutdown(self.protobufs.Empty()))
+            self._master_conn.kill()
+            self._master_conn = None
+            for wc in self._worker_conns:
+                wc.kill()
+            self._worker_conns = None
+            self._master = None
 
     def _try_rpc(self, fn):
         try:

--- a/scanner/api/database.h
+++ b/scanner/api/database.h
@@ -102,6 +102,7 @@ protected:
   struct ServerState {
     std::unique_ptr<grpc::Server> server;
     std::unique_ptr<grpc::Service> service;
+    std::unique_ptr<std::atomic<bool>> request_shutdown;
   };
 
 private:

--- a/scanner/engine/master.cpp
+++ b/scanner/engine/master.cpp
@@ -189,7 +189,8 @@ get_task_end_rows(const std::map<std::string, TableMetadata> &table_metas,
 
 class MasterImpl final : public proto::Master::Service {
 public:
-  MasterImpl(DatabaseParameters &params) : db_params_(params), bar_(nullptr) {
+  MasterImpl(DatabaseParameters &params, std::atomic<bool> &shutdown)
+      : db_params_(params), trigger_shutdown_(shutdown), bar_(nullptr) {
     storage_ =
         storehouse::StorageBackend::make_from_config(db_params_.storage_config);
     set_database_path(params.db_path);
@@ -521,10 +522,25 @@ public:
     return grpc::Status::OK;
   }
 
+  grpc::Status Shutdown(grpc::ServerContext *context,
+                        const proto::Empty *empty,
+                        Result *result) {
+    trigger_shutdown_ = true;
+    for (auto& w : workers_) {
+      grpc::ClientContext ctx;
+      proto::Empty empty;
+      proto::Result result;
+      w->Shutdown(&ctx, empty, &result);
+    }
+    result->set_success(true);
+    return grpc::Status::OK;
+  }
+
 private:
   std::vector<std::unique_ptr<proto::Worker::Stub>> workers_;
   std::vector<std::string> addresses_;
   DatabaseParameters db_params_;
+  std::atomic<bool>& trigger_shutdown_;
   storehouse::StorageBackend *storage_;
   std::map<std::string, TableMetadata> table_metas_;
   proto::JobParameters job_params_;
@@ -541,8 +557,9 @@ private:
   Result task_result_;
 };
 
-proto::Master::Service *get_master_service(DatabaseParameters &param) {
-  return new MasterImpl(param);
+proto::Master::Service *get_master_service(DatabaseParameters &param,
+                                           std::atomic<bool> &shutdown) {
+  return new MasterImpl(param, shutdown);
 }
 }
 }

--- a/scanner/engine/master.cpp
+++ b/scanner/engine/master.cpp
@@ -525,14 +525,15 @@ public:
   grpc::Status Shutdown(grpc::ServerContext *context,
                         const proto::Empty *empty,
                         Result *result) {
+    result->set_success(true);
     trigger_shutdown_ = true;
     for (auto& w : workers_) {
       grpc::ClientContext ctx;
       proto::Empty empty;
-      proto::Result result;
-      w->Shutdown(&ctx, empty, &result);
+      proto::Result wresult;
+      w->Shutdown(&ctx, empty, &wresult);
+      result->CopyFrom(&wresult);
     }
-    result->set_success(true);
     return grpc::Status::OK;
   }
 

--- a/scanner/engine/rpc.proto
+++ b/scanner/engine/rpc.proto
@@ -14,11 +14,13 @@ service Master {
   rpc Ping (Empty) returns (Empty) {}
   rpc LoadOp (OpInfo) returns (Result) {}
   rpc GetOpOutputInfo (OpOutputInfoArgs) returns (OpOutputInfo) {}
+  rpc Shutdown (Empty) returns (Result) {}
 }
 
 service Worker {
   rpc NewJob (JobParameters) returns (Result) {}
   rpc LoadOp (OpInfo) returns (Empty) {}
+  rpc Shutdown (Empty) returns (Result) {}
 }
 
 message Empty {}
@@ -30,6 +32,7 @@ message Result {
 
 message WorkerParams {
   string address = 1;
+  MachineParameters params = 2;
 }
 
 message Registration {

--- a/scanner/engine/runtime.h
+++ b/scanner/engine/runtime.h
@@ -61,11 +61,13 @@ struct DatabaseParameters {
   std::vector<i32> gpu_ids;
 };
 
-proto::Master::Service *get_master_service(DatabaseParameters &param);
+proto::Master::Service *get_master_service(DatabaseParameters &param,
+                                           std::atomic<bool> &shutdown);
 
 proto::Worker::Service *get_worker_service(DatabaseParameters &params,
                                            const std::string &master_address,
-                                           const std::string &worker_port);
+                                           const std::string &worker_port,
+                                           std::atomic<bool> &shutdown);
 
 }
 }


### PR DESCRIPTION
Added functionality for starting a cluster in python and supporting shutdown of services through an RPC call.

A very annoying problem right now is that the master and workers will not get cleaned up unless the python object that spawned the master/workers is properly cleaned up (i.e. `db.stop_cluster()`, the object is GC'ed). I'm not sure what the best way to handle this is other than having the master/worker implement some watchdog functionality which will cause them to shutdown if they do not hear from the client in some amount of time.