### PR TITLE
Support batched input for python kernel

### DIFF
--- a/examples/python_kernel/my_kernel.py
+++ b/examples/python_kernel/my_kernel.py
@@ -9,6 +9,9 @@ class MyOpKernel(scannerpy.Kernel):
         pass
 
     def execute(self, input_columns):
-        return [struct.pack('=q', 9000)]
+        input_count = len(input_columns[0])
+        column_count = len(input_columns)
+        return [[struct.pack('=q', 9000) for _ in xrange(input_count)] 
+                 for _ in xrange(column_count)]
 
 KERNEL = MyOpKernel

--- a/examples/python_kernel/my_kernel.py
+++ b/examples/python_kernel/my_kernel.py
@@ -1,17 +1,41 @@
 import scannerpy
 import struct
+import numpy as np
+from PIL import Image
+import StringIO
+import time
+import sys
+import cv2
 
 class MyOpKernel(scannerpy.Kernel):
-    def __init__(self, config, protobufs):
-        self.protobufs = protobufs
+  def __init__(self, config, protobufs):
+    self.protobufs = protobufs
 
-    def close(self):
-        pass
+  def close(self):
+    pass
 
-    def execute(self, input_columns):
-        input_count = len(input_columns[0])
-        column_count = len(input_columns)
-        return [[struct.pack('=q', 9000) for _ in xrange(input_count)] 
-                 for _ in xrange(column_count)]
+  def encode(arr, format="jpeg"):
+    im = Image.fromarray(arr)
+    buf = StringIO.StringIO()
+    im.save(buf, format=format)
+    output = buf.getvalue()
+    buf.close()
+    return output
+
+  def execute(self, input_columns):
+    # cv2_im = cv2.cvtColor(input_columns[0],cv2.COLOR_BGR2RGB)
+    # pil_im = Image.fromarray(input_columns[0])
+    # width, height = pil_im.size
+    # print('width {}, height {}'.format(width, height))
+    print np.shape(input_columns)
+    # print arr
+    # arr = input_columns[0]
+    # jpeg_image = encode(arr)
+    # print('Raw={:d}, Jpeg={:d}'.format(len(encode(arr, format="bmp")), len(jpeg_image)))
+      # print('list size :{:d}'.format(len(input_columns[0])))
+    input_count = len(input_columns[0])
+    column_count = len(input_columns)
+    return [[struct.pack('=q', 9000) for _ in xrange(input_count)] 
+             for _ in xrange(column_count)]
 
 KERNEL = MyOpKernel

--- a/examples/python_kernel/python.py
+++ b/examples/python_kernel/python.py
@@ -6,10 +6,10 @@ script_dir = os.path.dirname(os.path.abspath(__file__))
 with Database() as db:
     db.register_op('MyOp', [('frame', ColumnType.Video)], ['test'])
     kernel_path = script_dir + '/my_kernel.py'
-    db.register_python_kernel('MyOp', DeviceType.CPU, kernel_path)
+    db.register_python_kernel('MyOp', DeviceType.CPU, kernel_path, batch=1)
 
     frame = db.ops.FrameInput()
-    test = db.ops.MyOp(frame = frame)
+    test = db.ops.MyOp(frame = frame, batch = 50)
     output = db.ops.Output(columns=[test])
 
     job = Job(op_args={

--- a/examples/shot_detection/shot_detect.py
+++ b/examples/shot_detection/shot_detect.py
@@ -79,7 +79,9 @@ def main():
     total_start = time.time()
 
     #movie_path = util.download_video() if len(sys.argv) <= 1 else sys.argv[1]
-    movie_path = '/n/scanner/datasets/movies/private/kubo_and_the_two_strings_2016.mp4'
+    #movie_path = '/n/scanner/datasets/movies/private/kubo_and_the_two_strings_2016.mp4'
+    movie_path = util.download_video()
+
     print('Detecting shots in movie {}'.format(movie_path))
     movie_name = os.path.basename(movie_path)
 
@@ -118,6 +120,9 @@ def main():
         })
         bulk_job = BulkJob(output=output, jobs=[job])
         [hists_table] = db.run(bulk_job, force=True)
+
+        hists_table.profiler().write_trace('hist_shot.trace')
+
         print('\nTime: {:.1f}s, {:.1f} fps'.format(
             time.time() - s,
             movie_table.num_rows() / (time.time() - s)))
@@ -178,6 +183,8 @@ def main():
         bulk_job = BulkJob(output=output, jobs=[job])
 
         [montage_table] = db.run(bulk_job, force=True)
+
+        montage_table.profiler().write_trace('montage_shot.trace')
 
         # Stack all partial montages together
         montage_img = np.zeros((1, target_width * row_length, 3), dtype=np.uint8)

--- a/examples/tutorial/06_custom_op.py
+++ b/examples/tutorial/06_custom_op.py
@@ -1,4 +1,4 @@
-from scannerpy import Database, Job
+from scannerpy import Database, Job, DeviceType, BulkJob
 import os.path
 
 ################################################################################
@@ -33,3 +33,5 @@ with Database() as db:
     )
     bulk_job = BulkJob(output=output_op, jobs=[job])
     db.run(bulk_job, force=True)
+
+    print(db.summarize())

--- a/examples/tutorial/07_profiling.py
+++ b/examples/tutorial/07_profiling.py
@@ -1,4 +1,4 @@
-from scannerpy import Database, Job, DeviceType
+from scannerpy import Database, Job, DeviceType, BulkJob
 
 ################################################################################
 # This tutorial shows how to look at profiling information for your job.       #
@@ -11,8 +11,8 @@ with Database() as db:
     output_op = db.ops.Output(columns=[histogram])
     job = Job(
         op_args={
-            frame: db.table('example').column('frame')
-            output_op: 'example_hist_profile',
+            frame: db.table('example').column('frame'),
+            output_op: 'example_hist_profile'
         }
     )
     bulk_job = BulkJob(output=output_op, jobs=[job])
@@ -28,3 +28,5 @@ with Database() as db:
     # loading bytes from disk or the thread running your kernels. If you have
     # multiple pipelines or multiple nodes, you will see many of these evaluate
     # threads.
+    print(db.summarize())
+

--- a/examples/tutorial/resize_op/CMakeLists.txt
+++ b/examples/tutorial/resize_op/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 3.2.0 FATAL_ERROR)
 
 # Uncomment the line below and change the Scanner path to the repo you cloned:
-# set(SCANNER_PATH /path/to/scanner)
+set(SCANNER_PATH /opt/scanner)
 if(NOT SCANNER_PATH)
   message(FATAL_ERROR "You need to update the SCANNER_PATH in resize_op/CMakeLists.txt first.")
 endif()

--- a/examples/tutorial/resize_op/resize_op.cpp
+++ b/examples/tutorial/resize_op/resize_op.cpp
@@ -13,7 +13,7 @@
 
 // Custom kernels must inherit the Kernel class or any subclass thereof,
 // e.g. the VideoKernel which provides support for processing video frames.
-class MyResizeKernel : public scanner::VideoKernel {
+class MyResizeKernel : public scanner::BatchedKernel {
  public:
   // To allow ops to be customized by users at a runtime, e.g. to define the
   // target width and height of the MyResizeKernel, Scanner uses Google's Protocol
@@ -23,8 +23,8 @@ class MyResizeKernel : public scanner::VideoKernel {
   // In Python, users will provide the argument fields to the op constructor,
   // and these will get serialized into a string. This string is part of the
   // general configuration each kernel receives from the runtime, config.args.
-  MyResizeKernel(const scanner::Kernel::Config& config)
-      : scanner::VideoKernel(config) {
+  MyResizeKernel(const scanner::KernelConfig& config)
+      : scanner::BatchedKernel(config) {
     // The protobuf arguments must be decoded from the input string.
     MyResizeArgs args;
     args.ParseFromArray(config.args.data(), config.args.size());
@@ -43,7 +43,7 @@ class MyResizeKernel : public scanner::VideoKernel {
 
     // This must be called at the top of the execute method in any VideoKernel.
     // See the VideoKernel for the implementation check_frame_info.
-    check_frame(scanner::CPU_DEVICE, frame_column[0]);
+    // scanner::VideoKernel::check_frame(scanner::CPU_DEVICE, frame_column[0]);
 
     auto& resized_frame_column = output_columns[0];
     scanner::FrameInfo output_frame_info(

--- a/python/scannerpy/column.py
+++ b/python/scannerpy/column.py
@@ -185,6 +185,8 @@ class Column:
                 dtype = np.float32
             elif frame_type == self._db.protobufs.F64:
                 dtype = np.float64
+            # else:
+            #     dtype = np.uint8 # Qian: fixit! some nasty things happened
             parser_fn = parsers.raw_frame_gen(self._video_descriptor.height,
                                               self._video_descriptor.width,
                                               self._video_descriptor.channels,

--- a/python/scannerpy/config.py
+++ b/python/scannerpy/config.py
@@ -5,7 +5,6 @@ from subprocess import check_output
 from common import *
 from storehousepy import StorageConfig, StorageBackend
 
-
 def read_line(s):
     return sys.stdin.readline().strip()
 
@@ -69,6 +68,11 @@ class Config(object):
         elif storage_type == 'gcs':
             storage_config = StorageConfig.make_gcs_config(
                 storage['bucket'].encode('latin-1'))
+        elif storage_type == 's3':
+            storage_config = StorageConfig.make_s3_config(
+                storage['bucket'].encode('latin-1'),
+                storage['region'].encode('latin-1'),
+                storage['endpoint'].encode('latin-1'))
         else:
             raise ScannerException(
                 'Unsupported storage type {}'.format(storage_type))

--- a/python/scannerpy/database.py
+++ b/python/scannerpy/database.py
@@ -553,7 +553,8 @@ class Database:
             self.protobufs.add_module(proto_path)
         self._try_rpc(lambda: self._master.RegisterOp(op_registration))
 
-    def register_python_kernel(self, op_name, device_type, kernel_path):
+    def register_python_kernel(self, op_name, device_type, kernel_path, 
+                               batch=-1):
         with open(kernel_path, 'r') as f:
             kernel_str = f.read()
         py_registration = self.protobufs.PythonKernelRegistration()
@@ -562,6 +563,7 @@ class Database:
                                                           device_type)
         py_registration.kernel_str = kernel_str
         py_registration.pickled_config = pickle.dumps(self.config)
+        py_registration.batch_size = batch
         self._try_rpc(
             lambda: self._master.RegisterPythonKernel(py_registration))
 

--- a/python/scannerpy/database.py
+++ b/python/scannerpy/database.py
@@ -154,6 +154,7 @@ class Database:
         # Setup database metadata
         self._db_path = self.config.db_path
         self._storage = self.config.storage
+
         self._cached_db_metadata = None
         self._png_dump_prefix = '__png_dump_{:s}'
 
@@ -170,8 +171,10 @@ class Database:
         pydb_path = '{}/pydb'.format(self._db_path)
 
         pydbpath_info = self._storage.get_file_info(pydb_path+'/')
+        
 
         if not (pydbpath_info.file_exists and pydbpath_info.file_is_folder):
+            print('{:s} not exist, make_dir'.format(pydb_path))
             self._storage.make_dir(pydb_path)
             self._collections = self.protobufs.CollectionsDescriptor()
             self._update_collections()
@@ -793,6 +796,8 @@ class Database:
         else:
             job_id = job_name
 
+        # print('profiler return job_id: {}'.format(job_id))
+
         return Profiler(self, job_id)
 
     def _get_op_info(self, op_name):
@@ -899,7 +904,7 @@ class Database:
             cpu_pool=None,
             gpu_pool=None,
             pipeline_instances_per_node=None,
-            show_progress=True,
+            show_progress=False,
             profiling=False,
             load_sparsity_threshold=8,
             tasks_in_queue_per_pu=4):

--- a/python/scannerpy/stdlib/loaders.py
+++ b/python/scannerpy/stdlib/loaders.py
@@ -19,3 +19,6 @@ def bboxes(db, buf):
 
 def histograms(buf):
     return np.split(np.frombuffer(buf, dtype=np.dtype(np.int32)), 3)
+
+def classes(buf):
+    return np.split(np.frombuffer(buf, dtype=np.dtype(np.int32)), 1)

--- a/python/scannerpy/stdlib/parsers.py
+++ b/python/scannerpy/stdlib/parsers.py
@@ -43,6 +43,11 @@ def histograms(bufs, protobufs):
         return None
     return np.split(np.frombuffer(bufs[0], dtype=np.dtype(np.int32)), 3)
 
+def classes(bufs, protobufs):
+    if bufs[0] is None:
+        return None
+    return np.split(np.frombuffer(bufs[0], dtype=np.dtype(np.int32)), 1)
+
 
 def frame_info(buf, protobufs):
     info = protobufs.FrameInfo()

--- a/python/scannerpy/table.py
+++ b/python/scannerpy/table.py
@@ -91,6 +91,7 @@ class Table:
     def profiler(self):
         self._need_descriptor()
         if self._descriptor.job_id != -1:
+            # print('job_id is: {}'.format(self._descriptor.job_id))
             return self._db.profiler(self._descriptor.job_id)
         else:
             raise ScannerException('Ingested videos do not have profile data')

--- a/scanner/api/database.cpp
+++ b/scanner/api/database.cpp
@@ -63,7 +63,8 @@ internal::DatabaseParameters machine_params_to_db_params(
 
 MachineParameters default_machine_params() {
   MachineParameters machine_params;
-  machine_params.num_cpus = std::thread::hardware_concurrency();
+  // machine_params.num_cpus = std::thread::hardware_concurrency();
+  machine_params.num_cpus = 4;
   machine_params.num_load_workers = 8;
   machine_params.num_save_workers = 2;
 #ifdef HAVE_CUDA

--- a/scanner/engine/evaluate_worker.cpp
+++ b/scanner/engine/evaluate_worker.cpp
@@ -142,6 +142,7 @@ bool PreEvaluateWorker::yield(i32 item_size,
           u8* buffer = new_block_buffer(decoder_output_handle_,
                                         num_rows * frame_info.size(), num_rows);
           decoders_[media_col_idx]->get_frames(buffer, num_rows);
+
           for (i64 n = 0; n < num_rows; ++n) {
             insert_frame(entry.columns[c],
                          new Frame(frame_info, buffer + frame_info.size() * n));

--- a/scanner/engine/master.cpp
+++ b/scanner/engine/master.cpp
@@ -287,6 +287,7 @@ grpc::Status MasterImpl::NewJob(grpc::ServerContext* context,
                                 const proto::BulkJobParameters* job_params,
                                 proto::Result* job_result) {
   VLOG(1) << "Master received NewJob command";
+  // printf("Master received newjob!\n");
   job_result->set_success(true);
   set_database_path(db_params_.db_path);
 
@@ -461,6 +462,7 @@ grpc::Status MasterImpl::RegisterPythonKernel(
     const std::string& kernel_str = python_kernel->kernel_str();
     const std::string& pickled_config = python_kernel->pickled_config();
     const int batch_size = python_kernel->batch_size();
+
     // Create a kernel builder function
     auto constructor = [kernel_str, pickled_config](const KernelConfig& config) {
       return new PythonKernel(config, kernel_str, pickled_config);
@@ -725,6 +727,7 @@ bool MasterImpl::process_job(const proto::BulkJobParameters* job_params,
   auto& last_op = ops.at(ops.size() - 1);
   assert(last_op.name() == OUTPUT_OP_NAME);
   std::vector<std::vector<Column>> job_output_columns;
+
   for (const auto& job : jobs) {
     // Get input columns from column inputs specified for each job
     std::map<i64, Column> input_op_idx_to_column;

--- a/scanner/engine/rpc.proto
+++ b/scanner/engine/rpc.proto
@@ -86,6 +86,7 @@ message PythonKernelRegistration {
   DeviceType device_type = 2;
   string kernel_str = 3;
   string pickled_config = 4;
+  int32 batch_size = 5;
 }
 
 message IngestParameters {

--- a/scanner/engine/worker.cpp
+++ b/scanner/engine/worker.cpp
@@ -490,6 +490,7 @@ grpc::Status WorkerImpl::NewJob(grpc::ServerContext* context,
                                 proto::Result* job_result) {
   // Ensure that only one job is running at a time and that the worker
   // is in idle mode before transitioning to job start
+  // printf("Worker received a NewJob!\n");
   State state = state_.get();
   bool ready = false;
   while (!ready) {
@@ -744,6 +745,8 @@ grpc::Status WorkerImpl::NewJob(grpc::ServerContext* context,
   assert(num_kernel_groups > 0);  // is this actually necessary?
 
   i32 pipeline_instances_per_node = job_params->pipeline_instances_per_node();
+  // printf("pipeline_instances_per_node is: %d\n", pipeline_instances_per_node);
+  // printf("num_cpus is: %d\n", db_params_.num_cpus);
   // If ki per node is -1, we set a smart default. Currently, we calculate the
   // maximum possible kernel instances without oversubscribing any part of the
   // pipeline, either CPU or GPU.
@@ -810,7 +813,10 @@ grpc::Status WorkerImpl::NewJob(grpc::ServerContext* context,
     memory_pool_initialized_ = true;
   }
 
-  omp_set_num_threads(std::thread::hardware_concurrency());
+  int num_threads = 4;
+  // omp_set_num_threads(std::thread::hardware_concurrency());
+  omp_set_num_threads(num_threads);
+  printf("Number of threads: %d\n", std::thread::hardware_concurrency());
 
   // Setup shared resources for distributing work to processing threads
   i64 accepted_tasks = 0;
@@ -823,6 +829,7 @@ grpc::Status WorkerImpl::NewJob(grpc::ServerContext* context,
 
   // Setup load workers
   i32 num_load_workers = db_params_.num_load_workers;
+  // printf("db num_load_workers is: %d\n", num_load_workers);
   std::vector<Profiler> load_thread_profilers;
   for (i32 i = 0; i < num_load_workers; ++i) {
     load_thread_profilers.emplace_back(Profiler(base_time));
@@ -861,6 +868,8 @@ grpc::Status WorkerImpl::NewJob(grpc::ServerContext* context,
   std::condition_variable startup_cv;
   i32 startup_count = 0;
   i32 eval_total = 0;
+  // printf("pipeline_instances_per_node is: %d\n", pipeline_instances_per_node);
+  // printf("num_kernel_groups is: %d\n", num_kernel_groups);
   for (i32 ki = 0; ki < pipeline_instances_per_node; ++ki) {
     auto& work_queues = eval_work[ki];
     std::vector<Profiler>& eval_thread_profilers = eval_profilers[ki];
@@ -1014,6 +1023,7 @@ grpc::Status WorkerImpl::NewJob(grpc::ServerContext* context,
 
   // Setup save workers
   i32 num_save_workers = db_params_.num_save_workers;
+  // printf("num_save_workers is :%d\n", num_save_workers);
   std::vector<Profiler> save_thread_profilers;
   for (i32 i = 0; i < num_save_workers; ++i) {
     save_thread_profilers.emplace_back(Profiler(base_time));
@@ -1308,6 +1318,7 @@ grpc::Status WorkerImpl::NewJob(grpc::ServerContext* context,
   i64 out_rank = node_id_;
   // Load worker profilers
   u8 load_worker_count = num_load_workers;
+  // printf("num_load_workers: %d\n", num_load_workers);
   s_write(profiler_output.get(), load_worker_count);
   for (i32 i = 0; i < num_load_workers; ++i) {
     write_profiler_to_file(profiler_output.get(), out_rank, "load", "", i,
@@ -1523,6 +1534,7 @@ void WorkerImpl::register_with_master() {
   proto::MachineParameters* params = worker_info.mutable_params();
   params->set_num_cpus(db_params_.num_cpus);
   params->set_num_load_workers(db_params_.num_cpus);
+  // printf("register num_load_workers: %d\n", db_params_.num_cpus);
   params->set_num_save_workers(db_params_.num_cpus);
   for (i32 gpu_id : db_params_.gpu_ids) {
     params->add_gpu_ids(gpu_id);

--- a/scanner/engine/worker.cpp
+++ b/scanner/engine/worker.cpp
@@ -1420,13 +1420,20 @@ grpc::Status WorkerImpl::RegisterPythonKernel(
   DeviceType device_type = python_kernel->device_type();
   const std::string& kernel_str = python_kernel->kernel_str();
   const std::string& pickled_config = python_kernel->pickled_config();
+  const int batch_size = python_kernel->batch_size();
   // Create a kernel builder function
   auto constructor = [kernel_str, pickled_config](const KernelConfig& config) {
     return new PythonKernel(config, kernel_str, pickled_config);
   };
   // Create a new kernel factory
-  KernelFactory* factory =
-      new KernelFactory(op_name, device_type, 1, false, 1, constructor);
+  KernelFactory* factory;
+  if (batch_size > 0) {
+    factory = new KernelFactory(op_name, device_type, 1, true, 
+                                batch_size, constructor);
+  } else {
+    factory = new KernelFactory(op_name, device_type, 1, false, 
+                                1, constructor);
+  }
   // Register the kernel
   KernelRegistry* registry = get_kernel_registry();
   registry->add_kernel(op_name, factory);

--- a/scanner/video/video_decoder.cpp
+++ b/scanner/video/video_decoder.cpp
@@ -34,11 +34,14 @@ namespace internal {
 std::vector<VideoDecoderType> VideoDecoder::get_supported_decoder_types() {
   std::vector<VideoDecoderType> decoder_types;
 #ifdef HAVE_NVIDIA_VIDEO_HARDWARE
+  printf("has NVIDIA video decoder hardware\n");
   decoder_types.push_back(VideoDecoderType::NVIDIA);
 #endif
 #ifdef HAVE_INTEL_VIDEO_HARDWARE
+  printf("has INTEL video decoder hardware\n");
   decoder_types.push_back(VideoDecoderType::INTEL);
 #endif
+  // printf("only has software decoder\n");
   decoder_types.push_back(VideoDecoderType::SOFTWARE);
 
   return decoder_types;
@@ -63,6 +66,7 @@ VideoDecoder* VideoDecoder::make_from_config(DeviceHandle device_handle,
   switch (type) {
     case VideoDecoderType::NVIDIA: {
 #ifdef HAVE_NVIDIA_VIDEO_HARDWARE
+      printf("has NVIDIA video decoder hardware\n");
       // HACK(apoms): we are just going to assume all processing is done in the
       //   default context for now and retain it ourselves. Ideally we would
       //   allow the user to pass in the CUcontext they want to use for
@@ -85,12 +89,14 @@ VideoDecoder* VideoDecoder::make_from_config(DeviceHandle device_handle,
     }
     case VideoDecoderType::INTEL: {
 #ifdef HAVE_INTEL_VIDEO_HARDWARE
+      printf("has INTEL video decoder hardware\n");
       decoder = new IntelVideoDecoder(device_handle.id, device_handle.type);
 #else
 #endif
       break;
     }
     case VideoDecoderType::SOFTWARE: {
+      // printf("only has software decoder\n");
       decoder = new SoftwareVideoDecoder(device_handle.id, device_handle.type,
                                          num_devices);
       break;

--- a/tests/py_test.py
+++ b/tests/py_test.py
@@ -392,11 +392,11 @@ def test_python_kernel(db):
                    [('frame', ColumnType.Video)],
                    ['dummy'])
     db.register_python_kernel('TestPy', DeviceType.CPU,
-                              cwd + '/test_py_kernel.py')
+                              cwd + '/test_py_kernel.py', batch=10)
 
     frame = db.ops.FrameInput()
     range_frame = frame.sample()
-    test_out = db.ops.TestPy(frame=range_frame)
+    test_out = db.ops.TestPy(frame=range_frame, batch=10)
     output_op = db.ops.Output(columns=[test_out])
     job = Job(
         op_args={

--- a/tests/test_py_kernel.py
+++ b/tests/test_py_kernel.py
@@ -13,6 +13,9 @@ class TestPyKernel(scannerpy.Kernel):
         point = protobufs.Point()
         point.x = 10
         point.y = 5
-        return [point.SerializeToString()]
+        input_count = len(input_columns[0])
+        column_count = len(input_columns)
+        return [[point.SerializeToString() for _ in xrange(input_count)]
+                for _ in xrange(column_count)]
 
 KERNEL = TestPyKernel

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -52,8 +52,8 @@ if (NOT STOREHOUSE_FOUND)
   include(ProcessorCount)
   ProcessorCount(N)
   ExternalProject_Add(Storehouse
-    GIT_REPOSITORY "https://github.com/scanner-research/storehouse"
-    GIT_TAG "465bd309ddbe0dfa7b0cd9dd2a88f03e17650e90"
+    GIT_REPOSITORY "https://github.com/qinglan233/storehouse"
+    #GIT_TAG "465bd309ddbe0dfa7b0cd9dd2a88f03e17650e90"
 
     UPDATE_COMMAND mkdir -p thirdparty/build && cd thirdparty/build &&
     cmake ${THIRDPARTY_SOURCE_DIR}/storehouse/thirdparty && make -j${N}


### PR DESCRIPTION
I added the "batch" feature for Scanner python kernels. For example, users can enable python kernel batch by:
```
db.register_python_kernel('MyOp', DeviceType.CPU, kernel_path, batch=10)
```
The `batch` here is the preferred batch size, and the real batch size is assigned during the construction of the job (e.g., `test = db.ops.MyOp(frame = frame, batch = 50)`).
If `batch` is not defined (or the batch size is less than 1) by the user when registering the kernel, then the batch feature will be disabled.

The data format of `input_columns` passed to Python kernel is changed to support batch feature  (added one dimension compared to current version), where the first dimension is the number of columns, then the second dimension is the number of rows. In short, now we pass the whole batch rather than one row at a time.

I also changed the py_test.py and test_py_kernel.py to use this new feature. All tests passed.