### PR TITLE
Support batched input for python kernel

### DIFF
--- a/python/scannerpy/database.py
+++ b/python/scannerpy/database.py
@@ -567,7 +567,8 @@ class Database:
             self.protobufs.add_module(proto_path)
         self._try_rpc(lambda: self._master.RegisterOp(op_registration))
 
-    def register_python_kernel(self, op_name, device_type, kernel_path):
+    def register_python_kernel(self, op_name, device_type, kernel_path, 
+                               batch=1):
         with open(kernel_path, 'r') as f:
             kernel_str = f.read()
         py_registration = self.protobufs.PythonKernelRegistration()
@@ -576,6 +577,7 @@ class Database:
                                                           device_type)
         py_registration.kernel_str = kernel_str
         py_registration.pickled_config = pickle.dumps(self.config)
+        py_registration.batch_size = batch
         self._try_rpc(
             lambda: self._master.RegisterPythonKernel(py_registration))
 

--- a/scanner/engine/master.cpp
+++ b/scanner/engine/master.cpp
@@ -460,14 +460,17 @@ grpc::Status MasterImpl::RegisterPythonKernel(
     DeviceType device_type = python_kernel->device_type();
     const std::string& kernel_str = python_kernel->kernel_str();
     const std::string& pickled_config = python_kernel->pickled_config();
+    const int batch_size = python_kernel->batch_size();
     // Create a kernel builder function
-    auto constructor = [kernel_str, pickled_config](const KernelConfig& config) {
-      return new PythonKernel(config, kernel_str, pickled_config);
+    auto constructor = [kernel_str, pickled_config, batch_size](
+      const KernelConfig& config) {
+      return new PythonKernel(config, kernel_str, pickled_config, batch_size);
     };
     // Create a new kernel factory
     // TODO(apoms): Support batching and # of devices in python kernels
-    KernelFactory* factory =
-        new KernelFactory(op_name, device_type, 1, false, 1, constructor);
+    bool can_batch = (batch_size > 1);
+    KernelFactory* factory = new KernelFactory(op_name, device_type, 1, 
+                                    can_batch, batch_size, constructor);
     // Register the kernel
     KernelRegistry* registry = get_kernel_registry();
     registry->add_kernel(op_name, factory);

--- a/scanner/engine/python_kernel.cpp
+++ b/scanner/engine/python_kernel.cpp
@@ -31,9 +31,11 @@ std::string handle_pyerror() {
 
 PythonKernel::PythonKernel(const KernelConfig& config,
                            const std::string& kernel_str,
-                           const std::string& pickled_config)
+                           const std::string& pickled_config,
+                           const int preferred_batch)
   : BatchedKernel(config), config_(config), device_(config.devices[0]) {
   PyGILState_STATE gstate = PyGILState_Ensure();
+  can_batch_ = (preferred_batch > 1);
   try {
     py::object main = py::import("__main__");
     main.attr("kernel_str") = py::str(kernel_str);
@@ -69,8 +71,114 @@ PythonKernel::~PythonKernel() {
   PyGILState_Release(gstate);
 }
 
-void PythonKernel::execute(const BatchedColumns& input_columns,
-                           BatchedColumns& output_columns) {
+void PythonKernel::batched_python_execute(const BatchedColumns& input_columns,
+                                          BatchedColumns& output_columns) {
+  i32 input_count = (i32)num_rows(input_columns[0]);
+  PyGILState_STATE gstate = PyGILState_Ensure();
+
+  try {
+    py::object main = py::import("__main__");
+    py::object kernel = main.attr("kernel");
+
+    py::list batched_cols;
+    for (i32 j = 0; j < input_columns.size(); ++j) {
+      py::list rows;
+      // HACK(wcrichto): should pass column type in config and check here
+      if (config_.input_column_types[j] == proto::ColumnType::Video) {
+        for (i32 i = 0; i < input_count; ++i) {
+          const Frame *frame = input_columns[j][i].as_const_frame();
+          np::ndarray frame_np = 
+            np::from_data(frame->data, np::dtype::get_builtin<uint8_t>(),
+                            py::make_tuple(frame->height(), frame->width(),
+                                           frame->channels()),
+                            py::make_tuple(frame->width() * frame->channels(),
+                                           frame->channels(), 1),
+                            py::object());
+          rows.append(frame_np);
+        }
+      } else {
+        for (i32 i = 0; i < input_count; ++i) {
+          rows.append(py::str((char const*)input_columns[j][i].buffer,
+                              input_columns[j][i].size));
+        }
+      }
+      batched_cols.append(rows);
+    }
+
+    py::list batched_out_cols = py::extract<py::list>(kernel.attr("execute")(batched_cols));
+    LOG_IF(FATAL, py::len(batched_out_cols) != output_columns.size())
+          << "Incorrect number of output columns. Expected "
+          << output_columns.size();
+
+    for (i32 j = 0; j < output_columns.size(); ++j) {
+      // push all rows to that column
+      LOG_IF(FATAL, py::len(batched_out_cols[j]) != input_count)
+          << "Incorrect number of output rows. Expected "
+          << input_count;
+      if (config_.output_columns[j] == "frame") {
+        for (i32 i = 0; i < input_count; ++i) {
+          np::ndarray frame_np = py::extract<np::ndarray>(batched_out_cols[j][i]);
+          FrameType frame_type;
+          {
+            np::dtype dtype = frame_np.get_dtype();
+            if (dtype == np::dtype::get_builtin<uint8_t>()) {
+              frame_type = FrameType::U8;
+            } else if (dtype == np::dtype::get_builtin<f32>()) {
+              frame_type = FrameType::F32;
+            } else if (dtype == np::dtype::get_builtin<f64>()) {
+              frame_type = FrameType::F64;
+            } else {
+              LOG(FATAL) << "Invalid numpy dtype: "
+                         << py::extract<char const*>(py::str(dtype));
+            }
+          }
+          i32 ndim = frame_np.get_nd();
+          if (ndim > 3) {
+            LOG(FATAL) << "Invalid number of dimensions (must be less than 4): "
+                       << ndim;
+          }
+          std::vector<i32> shapes;
+          std::vector<i32> strides;
+          for (int n = 0; n < ndim; ++n) {
+            shapes.push_back(frame_np.shape(n));
+            strides.push_back(frame_np.strides(n));
+          }
+          FrameInfo frame_info(shapes, frame_type);
+          Frame* frame = new_frame(device_, frame_info);
+          const char* frame_data = frame_np.get_data();
+
+          if (ndim == 3) {
+            assert(strides[1] % strides[2] == 0);
+            for (int i = 0; i < shapes[0]; ++i) {
+              u64 offset = strides[0] * i;
+              memcpy(frame->data + offset, frame_data + offset,
+                     shapes[2] * shapes[1] * strides[2]);
+            }
+          } else {
+            LOG(FATAL) << "Can not support ndim != 3.";
+          }
+          insert_frame(output_columns[j], frame);
+        }
+      } else {
+        for (i32 i = 0; i < input_count; ++i) {
+          std::string field = py::extract<std::string>(batched_out_cols[j][i]);
+          size_t size = field.size();
+          u8* buf = new_buffer(device_, size);
+          memcpy_buffer(buf, device_, (u8*)field.data(), CPU_DEVICE, size);
+          insert_element(output_columns[j], buf, size);
+        }
+      }
+    }
+    
+  } catch (py::error_already_set& e) {
+    LOG(FATAL) << handle_pyerror();
+  }
+
+  PyGILState_Release(gstate);
+}
+
+void PythonKernel::single_python_execute(const BatchedColumns& input_columns,
+                                         BatchedColumns& output_columns) {
   i32 input_count = (i32)num_rows(input_columns[0]);
 
   PyGILState_STATE gstate = PyGILState_Ensure();
@@ -162,6 +270,16 @@ void PythonKernel::execute(const BatchedColumns& input_columns,
   }
 
   PyGILState_Release(gstate);
+}
+
+void PythonKernel::execute(const BatchedColumns& input_columns,
+                           BatchedColumns& output_columns) {
+  if (can_batch_) {
+    batched_python_execute(input_columns, output_columns);
+  } else {
+    single_python_execute(input_columns, output_columns);
+  }
+  
 }
 
 }

--- a/scanner/engine/python_kernel.h
+++ b/scanner/engine/python_kernel.h
@@ -11,7 +11,8 @@ namespace scanner {
 class PythonKernel : public BatchedKernel {
  public:
   PythonKernel(const KernelConfig& config, const std::string& kernel_str,
-               const std::string& pickled_config);
+               const std::string& pickled_config,
+               const int preferred_batch = 1);
 
   ~PythonKernel();
 
@@ -19,8 +20,13 @@ class PythonKernel : public BatchedKernel {
                BatchedColumns& output_columns) override;
 
  private:
+  void batched_python_execute(const BatchedColumns& input_columns,
+                              BatchedColumns& output_columns);
+  void single_python_execute(const BatchedColumns& input_columns,
+                             BatchedColumns& output_columns);
   KernelConfig config_;
   DeviceHandle device_;
+  bool can_batch_;
 };
 
 }

--- a/scanner/engine/rpc.proto
+++ b/scanner/engine/rpc.proto
@@ -86,6 +86,7 @@ message PythonKernelRegistration {
   DeviceType device_type = 2;
   string kernel_str = 3;
   string pickled_config = 4;
+  int32 batch_size = 5;
 }
 
 message IngestParameters {

--- a/scanner/engine/worker.cpp
+++ b/scanner/engine/worker.cpp
@@ -1424,13 +1424,16 @@ grpc::Status WorkerImpl::RegisterPythonKernel(
   DeviceType device_type = python_kernel->device_type();
   const std::string& kernel_str = python_kernel->kernel_str();
   const std::string& pickled_config = python_kernel->pickled_config();
+  const int batch_size = python_kernel->batch_size();
   // Create a kernel builder function
-  auto constructor = [kernel_str, pickled_config](const KernelConfig& config) {
-    return new PythonKernel(config, kernel_str, pickled_config);
+  auto constructor = [kernel_str, pickled_config, batch_size](
+    const KernelConfig& config) {
+    return new PythonKernel(config, kernel_str, pickled_config, batch_size);
   };
   // Create a new kernel factory
-  KernelFactory* factory =
-      new KernelFactory(op_name, device_type, 1, false, 1, constructor);
+  bool can_batch = (batch_size > 1);
+  KernelFactory* factory = new KernelFactory(op_name, device_type, 1, 
+                                  can_batch, batch_size, constructor);
   // Register the kernel
   KernelRegistry* registry = get_kernel_registry();
   registry->add_kernel(op_name, factory);

--- a/tests/py_test.py
+++ b/tests/py_test.py
@@ -410,6 +410,29 @@ def test_python_kernel(db):
     tables = db.run(bulk_job, force=True, show_progress=False)
     next(tables[0].load(['dummy']))
 
+def test_python_batch_kernel(db):
+    db.register_op('TestPyBatch',
+                   [('frame', ColumnType.Video)],
+                   ['dummy'])
+    db.register_python_kernel('TestPyBatch', DeviceType.CPU,
+                              cwd + '/test_py_batch_kernel.py', batch=10)
+
+    frame = db.ops.FrameInput()
+    range_frame = frame.sample()
+    test_out = db.ops.TestPyBatch(frame=range_frame, batch=50)
+    output_op = db.ops.Output(columns=[test_out])
+    job = Job(
+        op_args={
+            frame: db.table('test1').column('frame'),
+            range_frame: db.sampler.range(0, 30),
+            output_op: 'test_hist'
+        }
+    )
+    bulk_job = BulkJob(output=output_op, jobs=[job])
+
+    tables = db.run(bulk_job, force=True, show_progress=False)
+    next(tables[0].load(['dummy']))
+
 def test_blur(db):
     frame = db.ops.FrameInput()
     range_frame = frame.sample()

--- a/tests/test_py_batch_kernel.py
+++ b/tests/test_py_batch_kernel.py
@@ -1,0 +1,21 @@
+import scannerpy
+import scannerpy.stdlib.writers as writers
+
+class TestPyBatchKernel(scannerpy.Kernel):
+    def __init__(self, config, protobufs):
+        self.protobufs = protobufs
+        pass
+
+    def close(self):
+        pass
+
+    def execute(self, input_columns):
+        point = protobufs.Point()
+        point.x = 10
+        point.y = 5
+        input_count = len(input_columns[0])
+        column_count = len(input_columns)
+        return [[point.SerializeToString() for _ in xrange(input_count)]
+                 for _ in xrange(column_count)]
+
+KERNEL = TestPyBatchKernel


### PR DESCRIPTION
(Sorry I screwed up my previous pull request, so I have to create a new one!)

I added the "batch" feature for Scanner python kernels. For example, users can enable python kernel batch by:
```
db.register_python_kernel('MyOp', DeviceType.CPU, kernel_path, batch=10)
```
The `batch` here is the preferred batch size, and the real batch size is assigned during the construction of the job (e.g., `test = db.ops.MyOp(frame = frame, batch = 50)`).
If `batch` is not defined (or the batch size is less than 1) by the user when registering the kernel, then the batch feature will be disabled.

The data format of `input_columns` passed to Python kernel is changed to support batch feature  (added one dimension compared to current version), where the first dimension is the number of columns, then the second dimension is the number of rows. In short, now we pass the whole batch rather than one row at a time.

I also changed the py_test.py and test_py_kernel.py to use this new feature. All tests passed.