### PR TITLE
S3 patch

### DIFF
--- a/python/scannerpy/config.py
+++ b/python/scannerpy/config.py
@@ -69,6 +69,11 @@ class Config(object):
         elif storage_type == 'gcs':
             storage_config = StorageConfig.make_gcs_config(
                 storage['bucket'].encode('latin-1'))
+        elif storage_type == 's3':
+            storage_config = StorageConfig.make_s3_config(
+                storage['bucket'].encode('latin-1'),
+                storage['region'].encode('latin-1'),
+                storage['endpoint'].encode('latin-1'))
         else:
             raise ScannerException(
                 'Unsupported storage type {}'.format(storage_type))


### PR DESCRIPTION
(Sorry I screwed up the last pull request, so I reopened a new one.)
Try to add S3 storage support for Scanner. Also need to update storehouse package.

In order to use S3, the user needs to provide aws_access_key_id and aws_screte_access_key:
```
export AWS_ACCESS_KEY_ID=<Access Key>
export AWS_SECRET_ACCESS_KEY=<Secret>
```

And a demo of ~/.scanner.toml file to use S3:
```
[storage]
type = "s3"
bucket = "<your bucket name>"
db_path = "scanner_db"
region = "us-west-2(change to your S3 bucket region)"
endpoint = "s3.dualstack.us-west-2.amazonaws.com (change to your S3 endpoint)"
```