### PR TITLE
Add support for GPU Python Kernels + GPU kernels with CPU input/output columns

### DIFF
--- a/python/scannerpy/__init__.py
+++ b/python/scannerpy/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
-from scannerpy.common import ScannerException, DeviceType, ColumnType
+from scannerpy.common import ScannerException, DeviceType, DeviceHandle, ColumnType
 from scannerpy.job import Job
 from scannerpy.bulk_job import BulkJob
 from scannerpy.database import Database, ProtobufGenerator, start_master, start_worker
 from scannerpy.config import Config
-from scannerpy.kernel import Kernel
+from scannerpy.kernel import Kernel, KernelConfig

--- a/python/scannerpy/common.py
+++ b/python/scannerpy/common.py
@@ -24,6 +24,12 @@ class DeviceType(enum.Enum):
             raise ScannerException('Invalid device type')
 
 
+class DeviceHandle(object):
+    def __init__(self, device, device_id):
+        self.device = device
+        self.device_id = device_id
+
+
 class ColumnType(enum.Enum):
     """ Enum for specifying what the type of a column is. """
     Blob = 0

--- a/python/scannerpy/kernel.py
+++ b/python/scannerpy/kernel.py
@@ -1,5 +1,16 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+class KernelConfig(object):
+    def __init__(self, device_handles, input_columns, input_column_types,
+                 output_columns, args, node_id):
+        self.devices = device_handles
+        self.input_columns = input_columns
+        self.input_column_types = input_column_types
+        self.output_columns = output_columns
+        self.args = args
+        self.node_id = node_id
+
+
 class Kernel(object):
     def __init__(self, config, protobufs):
         self.protobufs = protobufs

--- a/python/scannerpy/stdlib/bbox_nms_kernel.py
+++ b/python/scannerpy/stdlib/bbox_nms_kernel.py
@@ -9,7 +9,7 @@ class BBoxNMSKernel(scannerpy.Kernel):
     def __init__(self, config, protobufs):
         self.protobufs = protobufs
         args = protobufs.BBoxNMSArgs()
-        args.ParseFromString(config)
+        args.ParseFromString(config.args)
         self.scale = args.scale
 
     def close(self):

--- a/python/scannerpy/stdlib/pose_nms_kernel.py
+++ b/python/scannerpy/stdlib/pose_nms_kernel.py
@@ -9,7 +9,7 @@ class PoseNMSKernel(scannerpy.Kernel):
     def __init__(self, config, protobufs):
         self.protobufs = protobufs
         args = protobufs.PoseNMSArgs()
-        args.ParseFromString(config)
+        args.ParseFromString(config.args)
         self.height = args.height
 
     def close(self):

--- a/scanner/api/kernel.cpp
+++ b/scanner/api/kernel.cpp
@@ -132,11 +132,14 @@ KernelRegistration::KernelRegistration(const KernelBuilder& builder) {
   const std::string& name = builder.name_;
   DeviceType type = builder.device_type_;
   i32 num_devices = builder.num_devices_;
+  auto& input_devices = builder.input_devices_;
+  auto& output_devices = builder.output_devices_;
   bool can_batch = builder.can_batch_;
   i32 preferred_batch = builder.preferred_batch_size_;
   KernelConstructor constructor = builder.constructor_;
   internal::KernelFactory* factory = new internal::KernelFactory(
-      name, type, num_devices, can_batch, preferred_batch, constructor);
+      name, type, num_devices, input_devices, output_devices, can_batch,
+      preferred_batch, constructor);
   internal::KernelRegistry* registry = internal::get_kernel_registry();
   registry->add_kernel(name, factory);
 }

--- a/scanner/api/kernel.h
+++ b/scanner/api/kernel.h
@@ -424,6 +424,18 @@ class KernelBuilder {
     return *this;
   }
 
+  KernelBuilder& input_device(const std::string& input_name,
+                              DeviceType device_type) {
+    input_devices_[input_name] = device_type;
+    return *this;
+  }
+
+  KernelBuilder& output_device(const std::string& output_name,
+                               DeviceType device_type) {
+    output_devices_[output_name] = device_type;
+    return *this;
+  }
+
   KernelBuilder& batch(i32 preferred_batch_size = 1) {
     can_batch_ = true;
     preferred_batch_size = preferred_batch_size;
@@ -435,6 +447,8 @@ class KernelBuilder {
   KernelConstructor constructor_;
   DeviceType device_type_;
   i32 num_devices_;
+  std::map<std::string, DeviceType> input_devices_;
+  std::map<std::string, DeviceType> output_devices_;
   bool can_batch_;
   i32 preferred_batch_size_;
 };

--- a/scanner/engine/evaluate_worker.h
+++ b/scanner/engine/evaluate_worker.h
@@ -142,6 +142,8 @@ class EvaluateWorker {
 
   OpArgGroup arg_group_;
   std::vector<DeviceHandle> kernel_devices_;
+  std::vector<std::vector<DeviceHandle>> kernel_input_devices_;
+  std::vector<std::vector<DeviceHandle>> kernel_output_devices_;
   std::vector<i32> kernel_num_outputs_;
   std::vector<std::unique_ptr<BaseKernel>> kernels_;
 

--- a/scanner/engine/kernel_factory.h
+++ b/scanner/engine/kernel_factory.h
@@ -38,10 +38,14 @@ namespace internal {
 class KernelFactory {
  public:
   KernelFactory(const std::string& op_name, DeviceType type, i32 max_devices,
+                const std::map<std::string, DeviceType>& input_devices,
+                const std::map<std::string, DeviceType>& output_devices,
                 bool can_batch, i32 batch_size, KernelConstructor constructor)
     : op_name_(op_name),
       type_(type),
       max_devices_(max_devices),
+      input_devices_(input_devices),
+      output_devices_(output_devices),
       can_batch_(can_batch),
       preferred_batch_size_(batch_size),
       constructor_(constructor) {}
@@ -52,6 +56,14 @@ class KernelFactory {
   DeviceType get_device_type() const { return type_; }
 
   i32 get_max_devices() const { return max_devices_; }
+
+  const std::map<std::string, DeviceType>& get_input_devices() const {
+    return input_devices_;
+  }
+
+  const std::map<std::string, DeviceType>& get_output_devices() const {
+    return output_devices_;
+  }
 
   bool can_batch() const { return can_batch_; }
 
@@ -67,6 +79,8 @@ class KernelFactory {
   std::string op_name_;
   DeviceType type_;
   i32 max_devices_;
+  std::map<std::string, DeviceType> input_devices_;
+  std::map<std::string, DeviceType> output_devices_;
   bool can_batch_;
   i32 preferred_batch_size_;
   KernelConstructor constructor_;

--- a/scanner/engine/worker.cpp
+++ b/scanner/engine/worker.cpp
@@ -1428,10 +1428,28 @@ grpc::Status WorkerImpl::RegisterPythonKernel(
     const KernelConfig& config) {
     return new PythonKernel(config, kernel_str, pickled_config, batch_size);
   };
+  // Set all input and output columns to be CPU
+  std::map<std::string, DeviceType> input_devices;
+  std::map<std::string, DeviceType> output_devices;
+  {
+    OpRegistry* registry = get_op_registry();
+    OpInfo* info = registry->get_op_info(op_name);
+    if (info->variadic_inputs()) {
+      assert(device_type != DeviceType::GPU);
+    } else {
+      for (const auto& in_col : info->input_columns()) {
+        input_devices[in_col.name()] = DeviceType::CPU;
+      }
+    }
+    for (const auto& out_col : info->output_columns()) {
+      output_devices[out_col.name()] = DeviceType::CPU;
+    }
+  }
   // Create a new kernel factory
   bool can_batch = (batch_size > 1);
-  KernelFactory* factory = new KernelFactory(op_name, device_type, 1, 
-                                  can_batch, batch_size, constructor);
+  KernelFactory* factory =
+      new KernelFactory(op_name, device_type, 1, input_devices, output_devices,
+                        can_batch, batch_size, constructor);
   // Register the kernel
   KernelRegistry* registry = get_kernel_registry();
   registry->add_kernel(op_name, factory);


### PR DESCRIPTION
This PR modifies the python kernel constructor to match the C++ kernel constructor. Specifically, we pass in a KernelConfig python object with the same members as the C++ version. In order to support python kernels on the GPU, it also adds allows kernels to request that their column inputs are allocated in a device memory different from their own device requirement. For example, a GPU kernel can request that an input is received in CPU memory.

Addresses #98 since we can now access the device ID and Python kernels can have CPU inputs.