### PR TITLE
make build_graph() definition and call consistent

### DIFF
--- a/python/scannerpy/stdlib/kernel.py
+++ b/python/scannerpy/stdlib/kernel.py
@@ -8,9 +8,9 @@ class TensorFlowKernel(Kernel):
         # TODO: wrap this in "with device"
         self.config = config
         self.tf_config = tf.ConfigProto(allow_soft_placement = True)
-        self.sess = tf.Session(config=self.tf_config)
+        self.graph = self.build_graph()
+        self.sess = tf.Session(graph=self.graph, config=self.tf_config)
         self.sess.as_default()
-        self.graph = self.build_graph(self.sess)
         self.protobufs = protobufs
 
     def close(self):


### PR DESCRIPTION
This commit fixes:
1. `self.build_graph()` should take NO parameters but line 13 (`self.graph = self.build_graph(self.sess)`) calls it with `self.sess` parameter.
2. The original code first declares a session and then build a graph with the session. This commit builds a graph first and then passes the graph to session.