### PR TITLE
Fix config issue for S3 storage

### DIFF
--- a/python/scannerpy/config.py
+++ b/python/scannerpy/config.py
@@ -73,7 +73,7 @@ class Config(object):
         elif storage_type == 'gcs':
             storage_config = StorageConfig.make_gcs_config(
                 storage['bucket'].encode('latin-1'))
-        elif storage_type == 's3':
+        elif storage_type == 'aws':
             storage_config = StorageConfig.make_s3_config(
                 storage['bucket'].encode('latin-1'),
                 storage['region'].encode('latin-1'),


### PR DESCRIPTION
The storage type `s3` should actually be `aws` in python/scannerpy/config.py

Tested that Scanner can directly use AWS S3 as storage backend.