### PR TITLE
Convert to Python 3

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,14 +6,14 @@ pushd build
 if make -j$(nproc); then
     popd
     if rm -rf dist && \
-        python python/setup.py bdist_wheel;
+        python3 python/setup.py bdist_wheel;
     then
         cwd=$(pwd)
         # cd to /tmp to avoid name clashes with Python module name and any
         # directories of the same name in our cwd
         pushd /tmp
-        (yes | pip uninstall $PKG)
-        (yes | pip install $cwd/dist/*)
+        (yes | pip3 uninstall $PKG)
+        (yes | pip3 install $cwd/dist/*)
         popd
     fi
 else

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -45,7 +45,6 @@ find_package(FFmpeg REQUIRED)
 find_package(LibLZMA REQUIRED)
 find_package(OpenSSL REQUIRED)
 find_package(BZip2 REQUIRED)
-find_package(Boost COMPONENTS thread program_options regex python REQUIRED)
 find_package(GFlags REQUIRED)
 find_package(Glog REQUIRED)
 find_package(GoogleTest REQUIRED)
@@ -55,9 +54,11 @@ find_package(Storehouse REQUIRED CONFIG
   PATHS "${CMAKE_SOURCE_DIR}/thirdparty/install")
 find_package(Hwang REQUIRED)
 find_package(TinyToml REQUIRED)
-find_package(PythonLibs 2.7 EXACT REQUIRED)
 find_package(OpenCV COMPONENTS ${OPENCV_DESIRED_COMPONENTS})
 find_package(OpenMP REQUIRED)
+
+set(PYBIND11_PYTHON_VERSION 3.5)
+find_package(pybind11 REQUIRED)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 
@@ -77,12 +78,9 @@ set(SCANNER_LIBRARIES
   "${CURL_LIBRARIES}"
   "${ICONV_LIBRARIES}"
   "${SCANNER_LIBRARIES}"
-  "-lpython2.7"
-  "${Boost_LIBRARIES}"
-  "${Boost_LIBRARY_DIRS}/libboost_python.so"
-  "${Boost_LIBRARY_DIRS}/libboost_numpy.so"
   "${STOREHOUSE_LIBRARIES}"
   "${OPENSSL_LIBRARIES}"
+  "${PYTHON_LIBRARIES}"
   "-ljpeg"
   "-lz"
   "-ldl"
@@ -103,7 +101,7 @@ include_directories(
   "${GLOG_INCLUDE_DIRS}"
   "${LIBLZMA_INCLUDE_DIRS}"
   "${PYTHON_INCLUDE_DIRS}"
-  "${Boost_INCLUDE_DIRS}")
+  "${pybind11_INCLUDE_DIR}")
 
 if (OpenCV_FOUND)
   list(APPEND SCANNER_LIBRARIES ${OpenCV_LIBRARIES})

--- a/docker/ubuntu16.04/Dockerfile.base
+++ b/docker/ubuntu16.04/Dockerfile.base
@@ -10,16 +10,15 @@ ARG cpu_only=OFF
 RUN apt-get update && apt-get upgrade -y && \
     apt-get install -y software-properties-common && \
     add-apt-repository -y ppa:git-core/ppa && \
-    add-apt-repository -y ppa:jonathonf/python-2.7 && \
     apt-get update && \
     apt-get install -y libssl-dev libcurl3-dev liblzma-dev libeigen3-dev  \
     libgoogle-glog-dev libatlas-base-dev libsuitesparse-dev libgflags-dev \
     libx264-dev libopenjpeg-dev libxvidcore-dev \
-    libpng-dev libjpeg-dev libbz2-dev git python-pip wget \
-    libleveldb-dev libsnappy-dev libhdf5-serial-dev liblmdb-dev python-dev \
-    llvm clang python-tk autoconf autogen libtool libtbb-dev libopenblas-dev \
-    liblapacke-dev swig yasm python2.7 cpio curl unzip openssl libssl-dev \
-    libgl-dev libcap-dev
+    libpng-dev libjpeg-dev libbz2-dev git wget \
+    libleveldb-dev libsnappy-dev libhdf5-serial-dev liblmdb-dev  \
+    llvm clang autoconf autogen libtool libtbb-dev libopenblas-dev \
+    liblapacke-dev swig yasm cpio curl unzip openssl libssl-dev \
+    libgl-dev libcap-dev python3-dev
 
 # Non-apt-installable dependencies
 ENV deps /deps

--- a/examples/tutorial/resize_kernel.py
+++ b/examples/tutorial/resize_kernel.py
@@ -10,13 +10,15 @@ class MyResizeKernel(scannerpy.Kernel):
     # are provided through a protobuf object that you manually deserialize. See resize.proto for the
     # protobuf definition.
     def __init__(self, config, protobufs):
-        self._width = config.args['width']
-        self._height = config.args['height']
+        print(config, protobufs)
+        # self._width = config.args['width']
+        # self._height = config.args['height']
 
     # execute is the core computation routine maps inputs to outputs, e.g. here resizes an input
     # frame to a smaller output frame.
     def execute(self, columns):
-        return [cv2.resize(columns[0], (self._width, self._height))]
+        return [cv2.resize(columns[0], (10, 10))]
+        # return [cv2.resize(columns[0], (self._width, self._height))]
 
 
 KERNEL = MyResizeKernel

--- a/python/scannerpy/__init__.py
+++ b/python/scannerpy/__init__.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 from scannerpy.common import ScannerException, DeviceType, DeviceHandle, ColumnType
 from scannerpy.job import Job
 from scannerpy.database import Database, ProtobufGenerator, start_master, start_worker

--- a/python/scannerpy/column.py
+++ b/python/scannerpy/column.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 import struct
 import math
 from subprocess import Popen, PIPE
@@ -68,7 +68,7 @@ class Column(object):
                 kf_offset += kfs_per_video
             return keyframes
         else:
-            return range(self._table.num_rows())
+            return list(range(self._table.num_rows()))
 
     def _load_output_file(self, item_id, rows, fn=None):
         assert len(rows) > 0
@@ -128,7 +128,7 @@ class Column(object):
 
         start_pos = None
         pos = 0
-        rows = rows if len(rows) > 0 else range(total_rows)
+        rows = rows if len(rows) > 0 else list(range(total_rows))
         for fi in range(total_rows):
             old_pos = pos
             pos += lens[fi]
@@ -167,7 +167,7 @@ class Column(object):
         i = 0
         rows_so_far = 0
         rows_idx = 0
-        rows = range(total_rows) if rows is None else rows
+        rows = list(range(total_rows)) if rows is None else rows
         prev = 0
         for item_id in range(num_items):
             start_row = prev

--- a/python/scannerpy/common.py
+++ b/python/scannerpy/common.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 import numpy as np
 import enum
 from collections import defaultdict

--- a/python/scannerpy/config.py
+++ b/python/scannerpy/config.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 import toml
 import sys
@@ -63,14 +62,11 @@ class Config(object):
             if 'network' in config:
                 network = config['network']
                 if 'master' in network:
-                    self.master_address = network['master'].encode(
-                        'ascii', 'ignore')
+                    self.master_address = network['master']
                 if 'master_port' in network:
-                    self.master_port = network['master_port'].encode(
-                        'ascii', 'ignore')
+                    self.master_port = network['master_port']
                 if 'worker_port' in network:
-                    self.worker_port = network['worker_port'].encode(
-                        'ascii', 'ignore')
+                    self.worker_port = network['worker_port']
 
         except KeyError as key:
             raise ScannerException(
@@ -82,13 +78,10 @@ class Config(object):
         if storage_type == 'posix':
             storage_config = StorageConfig.make_posix_config()
         elif storage_type == 'gcs':
-            storage_config = StorageConfig.make_gcs_config(
-                storage['bucket'].encode('latin-1'))
+            storage_config = StorageConfig.make_gcs_config(storage['bucket'])
         elif storage_type == 's3':
             storage_config = StorageConfig.make_s3_config(
-                storage['bucket'].encode('latin-1'),
-                storage['region'].encode('latin-1'),
-                storage['endpoint'].encode('latin-1'))
+                storage['bucket'], storage['region'], storage['endpoint'])
         else:
             raise ScannerException(
                 'Unsupported storage type {}'.format(storage_type))
@@ -106,6 +99,7 @@ class Config(object):
         sys.stdout.write(
             'Your Scanner configuration file ({}) does not exist. Create one? '
             '[Y/n] '.format(self.config_path))
+        sys.stdout.flush()
         if sys.stdin.readline().strip().lower() == 'n':
             print(
                 'Exiting script. Please create a Scanner configuration file or re-run this script and follow '
@@ -125,7 +119,7 @@ class Config(object):
 
     @staticmethod
     def default_config():
-        hostname = check_output(['hostname']).strip()
+        hostname = check_output(['hostname']).strip().decode('utf-8')
 
         db_path = os.path.expanduser('~/.scanner/db')
 

--- a/python/scannerpy/job.py
+++ b/python/scannerpy/job.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 
 class Job(object):
     """

--- a/python/scannerpy/kernel.py
+++ b/python/scannerpy/kernel.py
@@ -1,16 +1,15 @@
+import pickle
+
+
 class KernelConfig(object):
     def __init__(self, config):
-        pass
-
-    # def __init__(self, device_handles, input_columns, input_column_types,
-    #              output_columns, output_column_types, args, node_id):
-    #     self.devices = device_handles
-    #     self.input_columns = input_columns
-    #     self.input_column_types = input_column_types
-    #     self.output_columns = output_columns
-    #     self.output_column_types = output_column_types
-    #     self.args = args
-    #     self.node_id = node_id
+        self.devices = config.devices
+        self.input_columns = config.input_columns
+        self.input_column_types = config.input_column_types
+        self.output_columns = config.output_columns
+        self.output_column_types = config.output_column_types
+        self.args = pickle.loads(config.args())
+        self.node_id = config.node_id
 
 
 class Kernel(object):

--- a/python/scannerpy/kernel.py
+++ b/python/scannerpy/kernel.py
@@ -1,16 +1,16 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-
 class KernelConfig(object):
-    def __init__(self, device_handles, input_columns, input_column_types,
-                 output_columns, output_column_types, args, node_id):
-        self.devices = device_handles
-        self.input_columns = input_columns
-        self.input_column_types = input_column_types
-        self.output_columns = output_columns
-        self.output_column_types = output_column_types
-        self.args = args
-        self.node_id = node_id
+    def __init__(self, config):
+        pass
+
+    # def __init__(self, device_handles, input_columns, input_column_types,
+    #              output_columns, output_column_types, args, node_id):
+    #     self.devices = device_handles
+    #     self.input_columns = input_columns
+    #     self.input_column_types = input_column_types
+    #     self.output_columns = output_columns
+    #     self.output_column_types = output_column_types
+    #     self.args = args
+    #     self.node_id = node_id
 
 
 class Kernel(object):

--- a/python/scannerpy/op.py
+++ b/python/scannerpy/op.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 import grpc
 import copy
 import pickle
@@ -41,7 +41,7 @@ class OpColumn:
         else:
             raise ScannerException('Compression codec {} not currently '
                                    'supported. Available codecs are: {}.'
-                                   .format(' '.join(codecs.keys())))
+                                   .format(' '.join(list(codecs.keys()))))
 
     def compress_video(self, quality=-1, bitrate=-1, keyframe_distance=-1):
         self._assert_is_video()

--- a/python/scannerpy/partitioner.py
+++ b/python/scannerpy/partitioner.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 
 from scannerpy.common import *
 

--- a/python/scannerpy/profiler.py
+++ b/python/scannerpy/profiler.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 import struct
 import json
 
@@ -55,7 +55,7 @@ class Profiler:
         }
         traces = []
         next_tid = 0
-        for proc, (_, worker_profiler_groups) in self._profilers.iteritems():
+        for proc, (_, worker_profiler_groups) in self._profilers.items():
             for worker_type, profs in [('load', worker_profiler_groups['load']),
                                        ('decode', worker_profiler_groups['decode']),
                                        ('eval', worker_profiler_groups['eval']),
@@ -98,15 +98,15 @@ class Profiler:
                 return '{:2f}'.format(t / 1.0e9)
             return t
         return {k: self._convert_time(v) if isinstance(v, dict) else convert(v)
-                for (k, v) in d.iteritems()}
+                for (k, v) in d.items()}
 
     def total_time_interval(self):
-        intv, _ = self._profilers.values()[0]
+        intv, _ = list(self._profilers.values())[0]
         return intv
 
     def statistics(self):
         totals = {}
-        for (total_start, total_end), profiler in self._profilers.values():
+        for (total_start, total_end), profiler in list(self._profilers.values()):
             for kind in profiler:
                 if kind not in totals:
                     totals[kind] = {}
@@ -115,7 +115,7 @@ class Profiler:
                         if key not in totals[kind]:
                             totals[kind][key] = 0.0
                         totals[kind][key] += end-start
-                    for (name, value) in thread['counters'].iteritems():
+                    for (name, value) in thread['counters'].items():
                         if name not in totals[kind]:
                             totals[kind][name] = 0
                         totals[kind][name] += value

--- a/python/scannerpy/protobuf_generator.py
+++ b/python/scannerpy/protobuf_generator.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 import os.path
 import imp
 import sys
@@ -24,7 +24,7 @@ class ProtobufGenerator:
             self.add_module(mod)
 
     def add_module(self, path):
-        if isinstance(path, basestring):
+        if isinstance(path, str):
             if not os.path.isfile(path):
                 raise ScannerException('Protobuf path does not exist: {}'
                                        .format(path))
@@ -64,7 +64,7 @@ def python_to_proto(protos, proto_name, obj):
 
     def serialize_obj(args_proto, p, obj):
         if isinstance(obj, dict):
-            for k, v in obj.iteritems():
+            for k, v in obj.items():
                 if k not in p:
                     raise ScannerException(
                         'Protobuf does not have field {:s}'.format(k))

--- a/python/scannerpy/sampler.py
+++ b/python/scannerpy/sampler.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 
 from scannerpy.common import *
 

--- a/python/scannerpy/sink.py
+++ b/python/scannerpy/sink.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 import grpc
 import copy
 
@@ -25,8 +25,8 @@ class Sink:
                     'db.sinks.Column(columns={\'column_name\': col}).')
 
             columns = sink_args['columns']
-            self._output_names = [n for n, _ in columns.iteritems()]
-            self._inputs = [c for _, c in columns.iteritems()]
+            self._output_names = [n for n, _ in columns.items()]
+            self._inputs = [c for _, c in columns.items()]
 
             del sink_args['columns']
         else:

--- a/python/scannerpy/source.py
+++ b/python/scannerpy/source.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 import grpc
 import copy
 

--- a/python/scannerpy/stdlib/__init__.py
+++ b/python/scannerpy/stdlib/__init__.py
@@ -1,1 +1,1 @@
-from net_descriptor import NetDescriptor
+from .net_descriptor import NetDescriptor

--- a/python/scannerpy/stdlib/bbox_nms_kernel.py
+++ b/python/scannerpy/stdlib/bbox_nms_kernel.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 
 import scannerpy
 import scannerpy.stdlib.readers as readers

--- a/python/scannerpy/stdlib/bboxes.py
+++ b/python/scannerpy/stdlib/bboxes.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 import numpy as np
 
 from scannerpy.table import Table

--- a/python/scannerpy/stdlib/build_flags.py
+++ b/python/scannerpy/stdlib/build_flags.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 import os.path
 import sys
 

--- a/python/scannerpy/stdlib/kernel.py
+++ b/python/scannerpy/stdlib/kernel.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 from ..kernel import Kernel
 from scannerpy import DeviceType
 

--- a/python/scannerpy/stdlib/montage.py
+++ b/python/scannerpy/stdlib/montage.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 import cv2
 import math
 import numpy as np

--- a/python/scannerpy/stdlib/net_descriptor.py
+++ b/python/scannerpy/stdlib/net_descriptor.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 import toml
 
 from scannerpy.common import *

--- a/python/scannerpy/stdlib/pipelines.py
+++ b/python/scannerpy/stdlib/pipelines.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 import math
 import os.path
 

--- a/python/scannerpy/stdlib/pose_nms_kernel.py
+++ b/python/scannerpy/stdlib/pose_nms_kernel.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 
 import scannerpy
 import scannerpy.stdlib.readers as readers

--- a/python/scannerpy/stdlib/poses.py
+++ b/python/scannerpy/stdlib/poses.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 
 import numpy as np
 import cv2
@@ -146,7 +146,7 @@ def nms(orig_poses, overlapThresh):
                     overlaps[idx] += 1
 
         duplicates = []
-        for idx, num_overlaps in overlaps.iteritems():
+        for idx, num_overlaps in overlaps.items():
             if num_overlaps >= min(3, num_joints_per_pose[idx]):
                 for ii, idx2 in enumerate(idxs):
                     if idx == idx2:

--- a/python/scannerpy/stdlib/readers.py
+++ b/python/scannerpy/stdlib/readers.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 import numpy as np
 import struct
 

--- a/python/scannerpy/stdlib/util.py
+++ b/python/scannerpy/stdlib/util.py
@@ -1,7 +1,7 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 from ..config import mkdir_p
 import os
-import urllib2
+import urllib.request, urllib.error, urllib.parse
 import errno
 
 
@@ -18,7 +18,7 @@ def download_temp_file(url, local_path=None):
     mkdir_p(os.path.dirname(local_path))
     if not os.path.isfile(local_path):
         print('Downloading {:s} to {:s}...'.format(url, local_path))
-        f = urllib2.urlopen(url)
+        f = urllib.request.urlopen(url)
         with open(local_path, 'wb') as local_f:
             local_f.write(f.read())
     return local_path

--- a/python/scannerpy/stdlib/video.py
+++ b/python/scannerpy/stdlib/video.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 import cv2
 
 def write_video(path, frames, fps=24.0):

--- a/python/scannerpy/stdlib/writers.py
+++ b/python/scannerpy/stdlib/writers.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 import struct
 
 

--- a/python/scannerpy/table.py
+++ b/python/scannerpy/table.py
@@ -1,6 +1,6 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 import struct
-from itertools import izip
+
 from timeit import default_timer as now
 
 from scannerpy.common import *
@@ -107,7 +107,7 @@ class Table:
         if not self.committed():
             raise ScannerException('Table has not committed yet.')
         cols = [self.column(c).load(rows=rows) for c in columns]
-        for tup in izip(*cols):
+        for tup in zip(*cols):
             if fn is not None:
                 yield fn(tup, self._db)
             else:

--- a/python/setup.py
+++ b/python/setup.py
@@ -28,6 +28,7 @@ LIBRARIES = [
 for library in LIBRARIES:
     shutil.copy(library, PIP_DIR + '/scannerpy/')
 
+
 def copy_partial_tree(from_dir, to_dir, pattern):
     dest_paths = []
     try:
@@ -40,35 +41,35 @@ def copy_partial_tree(from_dir, to_dir, pattern):
         dest_paths.append(os.path.join(to_dir, os.path.basename(f)))
 
     # List all directories in from_dir
-    for d in [p for p in os.listdir(from_dir)
-              if os.path.isdir(os.path.join(from_dir, p))]:
+    for d in [
+            p for p in os.listdir(from_dir)
+            if os.path.isdir(os.path.join(from_dir, p))
+    ]:
         print('dir', d)
         dest_paths += copy_partial_tree(
-            os.path.join(from_dir, d),
-            os.path.join(to_dir, d),
-            pattern)
+            os.path.join(from_dir, d), os.path.join(to_dir, d), pattern)
     return dest_paths
+
 
 def glob_files(path, prefix=''):
     all_paths = os.listdir(path)
-    files = [os.path.join(prefix, p) for p in all_paths
-             if os.path.isfile(os.path.join(path, p))]
-    for d in [p for p in all_paths
-              if os.path.isdir(os.path.join(path, p))]:
-        files += glob_files(os.path.join(path, d),
-                            prefix=os.path.join(prefix, d))
+    files = [
+        os.path.join(prefix, p) for p in all_paths
+        if os.path.isfile(os.path.join(path, p))
+    ]
+    for d in [p for p in all_paths if os.path.isdir(os.path.join(path, p))]:
+        files += glob_files(
+            os.path.join(path, d), prefix=os.path.join(prefix, d))
     return files
 
 
 # Copy built protobuf python files
 copy_partial_tree(
-    os.path.join(BUILD_DIR, 'scanner'),
-     os.path.join(PIP_DIR, 'scanner'),
+    os.path.join(BUILD_DIR, 'scanner'), os.path.join(PIP_DIR, 'scanner'),
     '*.py')
 copy_partial_tree(
     os.path.join(BUILD_DIR, 'stdlib'),
-     os.path.join(PIP_DIR, 'scanner', 'stdlib'),
-    '*.py')
+    os.path.join(PIP_DIR, 'scanner', 'stdlib'), '*.py')
 
 # Copy cmake files
 os.makedirs(os.path.join(PIP_DIR, 'scannerpy', 'cmake'))
@@ -76,49 +77,39 @@ shutil.copy(
     os.path.join(SCANNER_DIR, 'cmake', 'Util', 'Op.cmake'),
     os.path.join(PIP_DIR, 'scannerpy', 'cmake'))
 copy_partial_tree(
-     os.path.join(SCANNER_DIR, 'cmake', 'Modules'),
-     os.path.join(PIP_DIR, 'scannerpy', 'cmake', 'Modules'),
-    '*')
+    os.path.join(SCANNER_DIR, 'cmake', 'Modules'),
+    os.path.join(PIP_DIR, 'scannerpy', 'cmake', 'Modules'), '*')
 
-cmake_files = glob_files(
-    os.path.join(PIP_DIR, 'scannerpy', 'cmake'), 'cmake')
+cmake_files = glob_files(os.path.join(PIP_DIR, 'scannerpy', 'cmake'), 'cmake')
 
 # Copy scanner headers
 copy_partial_tree(
     os.path.join(SCANNER_DIR, 'scanner'),
-     os.path.join(PIP_DIR, 'scannerpy', 'include', 'scanner'),
-    '*.h')
+    os.path.join(PIP_DIR, 'scannerpy', 'include', 'scanner'), '*.h')
 copy_partial_tree(
     os.path.join(SCANNER_DIR, 'scanner'),
-    os.path.join(PIP_DIR, 'scannerpy', 'include', 'scanner'),
-    '*.inl')
+    os.path.join(PIP_DIR, 'scannerpy', 'include', 'scanner'), '*.inl')
 
 copy_partial_tree(
     os.path.join(BUILD_DIR, 'scanner'),
-    os.path.join(PIP_DIR, 'scannerpy', 'include', 'scanner'),
-    '*.h')
+    os.path.join(PIP_DIR, 'scannerpy', 'include', 'scanner'), '*.h')
 
 include_files = glob_files(
     os.path.join(PIP_DIR, 'scannerpy', 'include'), 'include')
 
-package_data = {
-    'scannerpy': [
-        './*.so'
-    ] + include_files + cmake_files
-}
+package_data = {'scannerpy': ['./*.so'] + include_files + cmake_files}
 
 REQUIRED_PACKAGES = [
-    'protobuf == 3.4.0',
-    'grpcio == 1.7.3',
-    'toml >= 0.9.2',
-    'enum34 >= 1.1.6',
-    'numpy >= 1.12.0',
-    'scipy >= 0.18.1',
-    'tqdm >= 4.19.5',
-    'python-prctl >= 1.7.0'
+    # 'protobuf == 3.4.0',
+    # 'grpcio == 1.7.3',
+    # 'toml >= 0.9.2',
+    # 'enum34 >= 1.1.6',
+    # 'numpy >= 1.12.0',
+    # 'scipy >= 0.18.1',
+    # 'tqdm >= 4.19.5',
+    # 'python-prctl >= 1.7.0'
 ]
 
-print(find_packages(where=PIP_DIR))
 setup(
     name='scannerpy',
     version='0.1.13',
@@ -127,14 +118,12 @@ setup(
     url='https://github.com/scanner-research/scanner',
     author='Alex Poms and Will Crichton',
     author_email='wcrichto@cs.stanford.edu',
-
     package_dir={'': PIP_DIR},
     packages=find_packages(where=PIP_DIR),
     install_requires=REQUIRED_PACKAGES,
     include_package_data=True,
     package_data=package_data,
     zip_safe=False,
-
     license='Apache 2.0',
     keywords='video distributed gpu',
 )

--- a/scanner/engine/python.cpp
+++ b/scanner/engine/python.cpp
@@ -1,133 +1,104 @@
+#include "scanner/api/kernel.h"
 #include "scanner/api/database.h"
 #include "scanner/engine/op_info.h"
 #include "scanner/engine/op_registry.h"
 #include "scanner/util/common.h"
-
-#include <boost/python.hpp>
-#include <boost/python/stl_iterator.hpp>
-#include <boost/python/numpy.hpp>
-#include <thread>
+#include <pybind11/pybind11.h>
 
 namespace scanner {
-namespace {
-class GILRelease {
- public:
-  inline GILRelease() {
-    PyEval_InitThreads();
-    m_thread_state = PyEval_SaveThread();
+
+  namespace py = pybind11;
+
+  py::bytes default_machine_params_wrapper() {
+    MachineParameters params = default_machine_params();
+    proto::MachineParameters params_proto;
+    params_proto.set_num_cpus(params.num_cpus);
+    params_proto.set_num_load_workers(params.num_load_workers);
+    params_proto.set_num_save_workers(params.num_save_workers);
+    for (auto gpu_id : params.gpu_ids) {
+      params_proto.add_gpu_ids(gpu_id);
+    }
+
+    std::string output;
+    bool success = params_proto.SerializeToString(&output);
+    LOG_IF(FATAL, !success) << "Failed to serialize machine params";
+    return py::bytes(output);
   }
 
-  inline ~GILRelease() {
-    PyEval_RestoreThread(m_thread_state);
-    m_thread_state = NULL;
+  proto::Result start_master_wrapper(Database& db, const std::string& port,
+                                     bool watchdog, bool prefetch_table_metadata,
+                                     i64 no_workers_timeout) {
+    py::gil_scoped_release release;
+    return db.start_master(default_machine_params(), port, watchdog,
+                           prefetch_table_metadata,
+                           no_workers_timeout);
   }
 
- private:
-  PyThreadState* m_thread_state;
-};
-}
+  proto::Result start_worker_wrapper(Database& db, const std::string& params_s,
+                                     const std::string& port, bool watchdog,
+                                     bool prefetch_table_metadata) {
+    py::gil_scoped_release release;
 
-namespace py = boost::python;
+    proto::MachineParameters params_proto;
+    params_proto.ParseFromString(params_s);
+    MachineParameters params;
+    params.num_cpus = params_proto.num_cpus();
+    params.num_load_workers = params_proto.num_load_workers();
+    params.num_save_workers = params_proto.num_save_workers();
+    for (auto gpu_id : params_proto.gpu_ids()) {
+      params.gpu_ids.push_back(gpu_id);
+    }
 
-template <typename T>
-inline std::vector<T> to_std_vector(const py::object& iterable) {
-  return std::vector<T>(py::stl_input_iterator<T>(iterable),
-                        py::stl_input_iterator<T>());
-}
-
-template <class T>
-py::list to_py_list(std::vector<T> vector) {
-  typename std::vector<T>::iterator iter;
-  py::list list;
-  for (iter = vector.begin(); iter != vector.end(); ++iter) {
-    list.append(*iter);
-  }
-  return list;
-}
-
-std::string default_machine_params_wrapper() {
-  MachineParameters params = default_machine_params();
-  proto::MachineParameters params_proto;
-  params_proto.set_num_cpus(params.num_cpus);
-  params_proto.set_num_load_workers(params.num_load_workers);
-  params_proto.set_num_save_workers(params.num_save_workers);
-  for (auto gpu_id : params.gpu_ids) {
-    params_proto.add_gpu_ids(gpu_id);
+    return db.start_worker(params, port, watchdog, prefetch_table_metadata);
   }
 
-  std::string output;
-  bool success = params_proto.SerializeToString(&output);
-  LOG_IF(FATAL, !success) << "Failed to serialize machine params";
-  return output;
-}
-
-proto::Result start_master_wrapper(Database& db, const std::string& port,
-                                   bool watchdog, bool prefetch_table_metadata,
-                                   i64 no_workers_timeout) {
-  GILRelease r;
-  return db.start_master(default_machine_params(), port, watchdog,
-                         prefetch_table_metadata,
-                         no_workers_timeout);
-}
-
-proto::Result start_worker_wrapper(Database& db, const std::string& params_s,
-                                   const std::string& port, bool watchdog,
-                                   bool prefetch_table_metadata) {
-  GILRelease r;
-  proto::MachineParameters params_proto;
-  params_proto.ParseFromString(params_s);
-  MachineParameters params;
-  params.num_cpus = params_proto.num_cpus();
-  params.num_load_workers = params_proto.num_load_workers();
-  params.num_save_workers = params_proto.num_save_workers();
-  for (auto gpu_id : params_proto.gpu_ids()) {
-    params.gpu_ids.push_back(gpu_id);
+  std::vector<FailedVideo> ingest_videos_wrapper(Database& db, std::vector<std::string> table_names,
+                                                 std::vector<std::string> paths,
+                                                 bool inplace) {
+    py::gil_scoped_release release;
+    std::vector<FailedVideo> failed_videos;
+    db.ingest_videos(table_names, paths, inplace, failed_videos);
+    return failed_videos;
   }
 
-  return db.start_worker(params, port, watchdog, prefetch_table_metadata);
-}
-
-py::list ingest_videos_wrapper(Database& db, const py::list table_names,
-                               const py::list paths,
-                               bool inplace) {
-  std::vector<FailedVideo> failed_videos;
-  {
-    GILRelease r;
-    db.ingest_videos(to_std_vector<std::string>(table_names),
-                     to_std_vector<std::string>(paths), inplace, failed_videos);
+  Result wait_for_server_shutdown_wrapper(Database& db) {
+    py::gil_scoped_release release;
+    return db.wait_for_server_shutdown();
   }
-  return to_py_list<FailedVideo>(failed_videos);
-}
 
-Result wait_for_server_shutdown_wrapper(Database& db) {
-  GILRelease r;
-  return db.wait_for_server_shutdown();
-}
+  PYBIND11_MODULE(libscanner, m) {
+    m.doc() = "Scanner C library";
 
-boost::shared_ptr<Database> initWrapper(storehouse::StorageConfig* sc,
-                                        const std::string& db_path,
-                                        const std::string& master_addr) {
-  GILRelease r;
-  return boost::shared_ptr<Database>( new Database(sc, db_path, master_addr) );
-}
-
-BOOST_PYTHON_MODULE(libscanner) {
-  boost::python::numpy::initialize();
-  using namespace py;
-  class_<Database, boost::noncopyable>("Database", no_init)
-      .def("__init__", make_constructor(&initWrapper))
+    py::class_<Database>(m, "Database")
+      .def(py::init<storehouse::StorageConfig*, const std::string&, const std::string&>())
       .def("ingest_videos", &Database::ingest_videos);
-  class_<FailedVideo>("FailedVideo", no_init)
+
+    py::class_<FailedVideo>(m, "FailedVideo")
       .def_readonly("path", &FailedVideo::path)
       .def_readonly("message", &FailedVideo::message);
-  class_<proto::Result>("Result", no_init)
-      .def("success", &proto::Result::success,
-           return_value_policy<return_by_value>())
-      .def("msg", &proto::Result::msg, return_value_policy<return_by_value>());
-  def("start_master", start_master_wrapper);
-  def("start_worker", start_worker_wrapper);
-  def("ingest_videos", ingest_videos_wrapper);
-  def("wait_for_server_shutdown", wait_for_server_shutdown_wrapper);
-  def("default_machine_params", default_machine_params_wrapper);
-}
+
+    py::class_<proto::Result>(m, "Result")
+      .def("success", &proto::Result::success)
+      .def("msg", &proto::Result::msg);
+
+    py::class_<KernelConfig>(m, "KernelConfig")
+      .def_readonly("devices", &KernelConfig::devices)
+      .def_readonly("input_columns", &KernelConfig::input_columns)
+      .def_readonly("input_column_types", &KernelConfig::input_column_types)
+      .def_readonly("output_columns", &KernelConfig::output_columns)
+      .def_readonly("output_column_types", &KernelConfig::output_column_types)
+      .def("args", [](const KernelConfig& config) {
+          std::string s(config.args.begin(), config.args.end());
+          return py::bytes(s);
+        });
+
+    // TODO: fill this type in
+    py::enum_<proto::ColumnType>(m, "ColumnType");
+
+    m.def("start_master", &start_master_wrapper);
+    m.def("start_worker", &start_worker_wrapper);
+    m.def("ingest_videos", &ingest_videos_wrapper);
+    m.def("wait_for_server_shutdown", &wait_for_server_shutdown_wrapper);
+    m.def("default_machine_params", &default_machine_params_wrapper);
+  }
 }

--- a/scanner/engine/python.cpp
+++ b/scanner/engine/python.cpp
@@ -3,7 +3,10 @@
 #include "scanner/engine/op_info.h"
 #include "scanner/engine/op_registry.h"
 #include "scanner/util/common.h"
+
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/functional.h>
 
 namespace scanner {
 
@@ -87,10 +90,14 @@ namespace scanner {
       .def_readonly("input_column_types", &KernelConfig::input_column_types)
       .def_readonly("output_columns", &KernelConfig::output_columns)
       .def_readonly("output_column_types", &KernelConfig::output_column_types)
+      .def_readonly("node_id", &KernelConfig::node_id)
       .def("args", [](const KernelConfig& config) {
           std::string s(config.args.begin(), config.args.end());
           return py::bytes(s);
         });
+
+    py::class_<DeviceHandle>(m, "DeviceHandle")
+      .def_readonly("id", &DeviceHandle::id);
 
     // TODO: fill this type in
     py::enum_<proto::ColumnType>(m, "ColumnType");

--- a/scanner/engine/python_kernel.cpp
+++ b/scanner/engine/python_kernel.cpp
@@ -1,398 +1,234 @@
 #include "scanner/engine/python_kernel.h"
-#include "scanner/util/util.h"
 #include "scanner/util/tinyformat.h"
+#include "scanner/util/util.h"
 
-#include <boost/python.hpp>
-#include <boost/python/numpy.hpp>
+#include <pybind11/pybind11.h>
+#include <pybind11/eval.h>
+#include <pybind11/numpy.h>
+#include <pybind11/stl.h>
 
 namespace scanner {
 
-namespace py = boost::python;
-namespace np = boost::python::numpy;
+namespace py = pybind11;
 
-std::string handle_pyerror() {
-  using namespace boost::python;
-  using namespace boost;
-
-  PyObject *exc, *val, *tb;
-  object formatted_list, formatted;
-  PyErr_Fetch(&exc, &val, &tb);
-  handle<> hexc(exc), hval(allow_null(val)), htb(allow_null(tb));
-  object traceback(import("traceback"));
-  if (!tb) {
-    object format_exception_only(traceback.attr("format_exception_only"));
-    formatted_list = format_exception_only(hexc, hval);
-  } else {
-    object format_exception(traceback.attr("format_exception"));
-    formatted_list = format_exception(hexc, hval, htb);
-  }
-  formatted = str("\n").join(formatted_list);
-  return extract<std::string>(formatted);
-}
-
-PythonKernel::PythonKernel(const KernelConfig& config,
-                           const std::string& op_name,
-                           const std::string& kernel_str,
-                           const std::string& pickled_config,
+PythonKernel::PythonKernel(const KernelConfig &config,
+                           const std::string &op_name,
+                           const std::string &kernel_str,
+                           const std::string &pickled_config,
                            const int preferred_batch)
-  : BatchedKernel(config), config_(config), device_(config.devices[0]), op_name_(op_name) {
-  PyGILState_STATE gstate = PyGILState_Ensure();
+    : BatchedKernel(config), config_(config), device_(config.devices[0]),
+      op_name_(op_name) {
+  py::gil_scoped_acquire acquire;
   can_batch_ = (preferred_batch > 1);
   kernel_name_ = tfm::format("%s_kernel", op_name_);
+
   try {
-    py::object main = py::import("__main__");
-    main.attr("kernel_str") = py::str(kernel_str);
-    main.attr("config_str") = py::str(pickled_config);
+    py::module main = py::module::import("__main__");
+    py::object scope = main.attr("__dict__");
+    main.attr("kernel_str") = kernel_str;
+    main.attr("user_config_str") = py::bytes(pickled_config);
+    main.attr("config") = config;
 
-    py::list devices;
-    py::list device_ids;
-    for (auto& handle : config.devices) {
-      devices.append(py::object(handle.type == DeviceType::CPU ? 0 : 1));
-      device_ids.append(py::object(handle.id));
-    }
-    py::list input_columns;
-    for (auto& inc : config.input_columns) {
-      input_columns.append(inc);
-    }
-    py::list input_column_types;
-    for (auto& inc : config.input_column_types) {
-      input_column_types.append(py::object(inc == ColumnType::Other ? 0 : 1));
-    }
-    py::list output_columns;
-    for (auto& outc : config.output_columns) {
-      output_columns.append(outc);
-    }
-    py::list output_column_types;
-    for (auto& inc : config.output_column_types) {
-      output_column_types.append(py::object(inc == ColumnType::Other ? 0 : 1));
-    }
-    py::str args((const char*)config.args.data(), config.args.size());
-    py::object node_id(config.node_id);
+    std::string pycode = tfm::format(R"(
+import pickle
+import traceback
+from scannerpy import Config, DeviceType, DeviceHandle, KernelConfig, ColumnType
+from scannerpy.protobuf_generator import ProtobufGenerator
 
-    main.attr("devices") = devices;
-    main.attr("device_ids") = device_ids;
-    main.attr("input_columns") = input_columns;
-    main.attr("input_column_types") = input_column_types;
-    main.attr("output_columns") = output_columns;
-    main.attr("output_column_types") = input_column_types;
-    main.attr("args") = args;
-    main.attr("node_id") = node_id;
-
-    py::object main_namespace = main.attr("__dict__");
-    std::string pycode = tfm::format(
-        "import pickle\n"
-        "from scannerpy import Config, DeviceType, DeviceHandle, KernelConfig, "
-        "ColumnType\n"
-        "from scannerpy.protobuf_generator import ProtobufGenerator\n"
-        "config = pickle.loads(config_str)\n"
-        "protobufs = ProtobufGenerator(config)\n"
-        "handles = [DeviceHandle(DeviceType(d), di)\n"
-        "           for d, di in zip(devices, device_ids)]\n"
-        "input_types = [ColumnType(c) for c in input_column_types]\n"
-        "output_types = [ColumnType(c) for c in output_column_types]\n"
-        "kernel_config = KernelConfig(handles, input_columns,\n"
-        "                             input_column_types, output_columns, output_column_types,\n"
-        "                             pickle.loads(args), node_id)\n"
-        "exec(kernel_str)\n"
-        "%s = KERNEL(kernel_config, protobufs)",
-        kernel_name_);
-    py::exec(pycode.c_str(), main_namespace);
-  } catch (py::error_already_set& e) {
-    LOG(FATAL) << handle_pyerror();
+user_config = pickle.loads(user_config_str)
+protobufs = ProtobufGenerator(user_config)
+kernel_config = KernelConfig(config)
+exec(kernel_str)
+%s = KERNEL(kernel_config, protobufs))",
+                                     kernel_name_);
+    py::exec(pycode, scope);
+  } catch (py::error_already_set &e) {
+    LOG(FATAL) << e.what();
   }
-  PyGILState_Release(gstate);
 }
 
 PythonKernel::~PythonKernel() {
-  PyGILState_STATE gstate = PyGILState_Ensure();
+  py::gil_scoped_acquire acquire;
   try {
-    py::object main = py::import("__main__");
-    py::object kernel = main.attr(py::str(kernel_name_));
-    kernel.attr("close")();
-  } catch (py::error_already_set& e) {
-    LOG(FATAL) << handle_pyerror();
+    py::module::import("__main__").attr(kernel_name_.c_str()).attr("close")();
+  } catch (py::error_already_set &e) {
+    LOG(FATAL) << e.what();
   }
-  PyGILState_Release(gstate);
 }
 
 void PythonKernel::reset() {
-  PyGILState_STATE gstate = PyGILState_Ensure();
+  py::gil_scoped_acquire acquire;
   try {
-    py::object main = py::import("__main__");
-    py::object kernel = main.attr(py::str(kernel_name_));
-    kernel.attr("reset")();
-  } catch (py::error_already_set& e) {
-    LOG(FATAL) << handle_pyerror();
+    py::module::import("__main__").attr(kernel_name_.c_str()).attr("reset")();
+  } catch (py::error_already_set &e) {
+    LOG(FATAL) << e.what();
   }
-  PyGILState_Release(gstate);
 }
 
-void PythonKernel::batched_python_execute(const BatchedElements& input_columns,
-                                          BatchedElements& output_columns) {
-  i32 input_count = (i32)num_rows(input_columns[0]);
-  PyGILState_STATE gstate = PyGILState_Ensure();
+void PythonKernel::new_stream(const std::vector<u8> &args) {
+  py::gil_scoped_acquire acquire;
 
   try {
-    py::object main = py::import("__main__");
-    py::object kernel = main.attr(py::str(kernel_name_));
+    py::module main = py::module::import("__main__");
+    py::object kernel = main.attr(kernel_name_.c_str());
+    main.attr("args_str") = py::bytes(reinterpret_cast<const char*>(args.data()),
+                                      args.size());
+    std::string pycode = tfm::format(R"(
+import pickle
+if len(args_str) == 0:
+  args = None
+else:
+  args = pickle.loads(args_str)
+%s.new_stream(args))",
+        kernel_name_);
+    py::exec(pycode.c_str(), main.attr("__dict__"));
+  } catch (py::error_already_set& e) {
+    LOG(FATAL) << e.what();
+  }
+}
 
-    py::list batched_cols;
+void PythonKernel::execute(const BatchedElements &input_columns,
+                           BatchedElements &output_columns) {
+  i32 input_count = (i32)num_rows(input_columns[0]);
+  py::gil_scoped_acquire acquire;
+
+  try {
+    py::object kernel =
+        py::module::import("__main__").attr(kernel_name_.c_str());
+
+    std::vector<std::vector<py::object>> batched_cols;
     for (i32 j = 0; j < input_columns.size(); ++j) {
-      py::list rows;
+      std::vector<py::object> rows;
       if (config_.input_column_types[j] == proto::ColumnType::Video) {
         for (i32 i = 0; i < input_count; ++i) {
           const Frame *frame = input_columns[j][i].as_const_frame();
-          np::dtype dtype = np::dtype::get_builtin<uint8_t>();
+          std::string dtype;
           u32 dtype_size;
           if (frame->type == FrameType::U8) {
-            dtype = np::dtype::get_builtin<uint8_t>();
+            dtype = py::format_descriptor<u8>::format();
             dtype_size = 1;
           } else if (frame->type == FrameType::F32) {
-            dtype = np::dtype::get_builtin<float>();
+            dtype = py::format_descriptor<f32>::format();
             dtype_size = 4;
           } else if (frame->type == FrameType::F64) {
-            dtype = np::dtype::get_builtin<double>();
+            dtype = py::format_descriptor<f64>::format();
             dtype_size = 8;
           }
-          np::ndarray frame_np =
-              np::from_data(frame->data, dtype,
-                            py::make_tuple(frame->height(), frame->width(),
-                                           frame->channels()),
-                            py::make_tuple(frame->width() * frame->channels() * dtype_size,
-                                           frame->channels() * dtype_size, dtype_size),
-                            py::object());
-          rows.append(frame_np);
+
+          py::buffer_info buffer(
+              frame->data, (size_t)dtype_size, dtype, 3,
+              {(long int)frame->height(), (long int)frame->width(),
+               (long int)frame->channels()},
+              {(long int)frame->width() * frame->channels() * dtype_size,
+               (long int)frame->channels() * dtype_size,
+                  (long int)dtype_size});
+
+          if (frame->type == FrameType::U8) {
+            rows.push_back(py::object(py::array_t<u8>(buffer)));
+          } else if (frame->type == FrameType::F32) {
+            rows.push_back(py::object(py::array_t<f32>(buffer)));
+          } else if (frame->type == FrameType::F64) {
+            rows.push_back(py::object(py::array_t<f64>(buffer)));
+          }
         }
       } else {
         for (i32 i = 0; i < input_count; ++i) {
-          rows.append(py::str((char const*)input_columns[j][i].buffer,
-                              input_columns[j][i].size));
+          rows.push_back(py::object(py::str((char const *)input_columns[j][i].buffer,
+                                            input_columns[j][i].size)));
         }
       }
-      batched_cols.append(rows);
+      batched_cols.push_back(rows);
     }
 
-    py::list batched_out_cols =
-        py::extract<py::list>(kernel.attr("execute")(batched_cols));
-    LOG_IF(FATAL, py::len(batched_out_cols) != output_columns.size())
-        << "Incorrect number of output columns. Expected "
-        << output_columns.size();
+    std::vector<std::vector<py::object>> batched_out_cols;
+
+    if (can_batch_) {
+    } else {
+         for (i32 j = 0; j < output_columns.size(); ++j) {
+              batched_out_cols.emplace_back();
+         }
+
+         for (auto& in_row : batched_cols) {
+              std::vector<py::object> out_row = kernel.attr("execute")(in_row).cast<std::vector<py::object>>();
+              for (i32 j = 0; j < out_row.size(); ++j) {
+                   batched_out_cols[j].push_back(out_row[j]);
+              }
+         }
+    }
+
+    // LOG_IF(FATAL, outputs.size() != output_columns.size())
+    //      << "Incorrect number of output columns. Expected "
+    //      << output_columns.size();
+
 
     for (i32 j = 0; j < output_columns.size(); ++j) {
       // push all rows to that column
-      LOG_IF(FATAL, py::len(batched_out_cols[j]) != input_count)
-          << "Incorrect number of output rows. Expected "
-          << input_count;
+      LOG_IF(FATAL, batched_out_cols[j].size() != input_count)
+          << "Incorrect number of output rows. Expected " << input_count;
       if (config_.output_column_types[j] == proto::ColumnType::Video) {
         for (i32 i = 0; i < input_count; ++i) {
-          np::ndarray frame_np =
-              py::extract<np::ndarray>(batched_out_cols[j][i]);
-          FrameType frame_type;
-          {
-            np::dtype dtype = frame_np.get_dtype();
-            if (dtype == np::dtype::get_builtin<uint8_t>()) {
-              frame_type = FrameType::U8;
-            } else if (dtype == np::dtype::get_builtin<f32>()) {
-              frame_type = FrameType::F32;
-            } else if (dtype == np::dtype::get_builtin<f64>()) {
-              frame_type = FrameType::F64;
-            } else {
-              LOG(FATAL) << "Invalid numpy dtype: "
-                         << py::extract<char const*>(py::str(dtype));
-            }
-          }
-          i32 ndim = frame_np.get_nd();
-          if (ndim > 3) {
-            LOG(FATAL) << "Invalid number of dimensions (must be less than 4): "
-                       << ndim;
-          }
-          std::vector<i32> shapes;
-          std::vector<i32> strides;
-          for (int n = 0; n < ndim; ++n) {
-            shapes.push_back(frame_np.shape(n));
-            strides.push_back(frame_np.strides(n));
-          }
-          FrameInfo frame_info(shapes, frame_type);
-          Frame* frame = new_frame(CPU_DEVICE, frame_info);
-          const char* frame_data = frame_np.get_data();
+             py::array frame_np = batched_out_cols[j][i].cast<py::array>();
+             FrameType frame_type;
+             if (frame_np.dtype().is(py::dtype("uint8"))) {
+                  frame_type = FrameType::U8;
+             } else if (frame_np.dtype().is(py::dtype("float"))) {
+                  frame_type = FrameType::F32;
+             } else if (frame_np.dtype().is(py::dtype("double"))) {
+                  frame_type = FrameType::F64;
+             } else {
+              LOG(FATAL) << "Invalid numpy dtype";
+             }
 
-          if (ndim == 3) {
-            assert(strides[1] % strides[2] == 0);
-            for (int i = 0; i < shapes[0]; ++i) {
-              u64 offset = strides[0] * i;
-              memcpy(frame->data + offset, frame_data + offset,
-                     shapes[2] * shapes[1] * strides[2]);
-            }
-          } else {
-            LOG(FATAL) << "Can not support ndim != 3.";
-          }
-          insert_frame(output_columns[j], frame);
+             i32 ndim = frame_np.ndim();
+             if (ndim > 3) {
+                  LOG(FATAL) << "Invalid number of dimensions (must be less than 4): "
+                             << ndim;
+             }
+             std::vector<i32> shapes;
+             std::vector<i32> strides;
+             for (int n = 0; n < ndim; ++n) {
+                  shapes.push_back(frame_np.shape(n));
+                  strides.push_back(frame_np.strides(n));
+             }
+             FrameInfo frame_info(shapes, frame_type);
+             Frame *frame = new_frame(CPU_DEVICE, frame_info);
+             const char *frame_data = (const char*) frame_np.data();
+
+             if (ndim == 3) {
+                  assert(strides[1] % strides[2] == 0);
+                  for (int i = 0; i < shapes[0]; ++i) {
+                       u64 offset = strides[0] * i;
+                       memcpy(frame->data + offset, frame_data + offset,
+                              shapes[2] * shapes[1] * strides[2]);
+                  }
+             } else {
+                  LOG(FATAL) << "Can not support ndim != 3.";
+             }
+             insert_frame(output_columns[j], frame);
         }
       } else {
         std::vector<std::string> outputs;
         size_t total_size = 0;
         for (i32 i = 0; i < input_count; ++i) {
-          std::string field = py::extract<std::string>(batched_out_cols[j][i]);
+          std::string field = batched_out_cols[j][i].cast<std::string>();
           outputs.push_back(field);
           total_size += field.size();
         }
 
-        u8* output_block = new_block_buffer(CPU_DEVICE, total_size, input_count);
+        u8 *output_block =
+            new_block_buffer(CPU_DEVICE, total_size, input_count);
         for (i32 i = 0; i < input_count; ++i) {
-          u8* buf = output_block;
-          memcpy_buffer(buf, CPU_DEVICE, (u8*)outputs[i].data(), CPU_DEVICE, outputs[i].size());
+          u8 *buf = output_block;
+          memcpy_buffer(buf, CPU_DEVICE, (u8 *)outputs[i].data(), CPU_DEVICE,
+                        outputs[i].size());
           insert_element(output_columns[j], buf, outputs[i].size());
           output_block += outputs[i].size();
         }
       }
     }
 
-  } catch (py::error_already_set& e) {
-    LOG(FATAL) << handle_pyerror();
+  } catch (py::error_already_set &e) {
+    LOG(FATAL) << e.what();
   }
-
-  PyGILState_Release(gstate);
 }
-
-void PythonKernel::single_python_execute(const BatchedElements& input_columns,
-                                         BatchedElements& output_columns) {
-  i32 input_count = (i32)num_rows(input_columns[0]);
-
-  PyGILState_STATE gstate = PyGILState_Ensure();
-
-  try {
-    py::object main = py::import("__main__");
-    py::object kernel = main.attr(py::str(kernel_name_));
-
-    for (i32 i = 0; i < input_count; ++i) {
-      py::list cols;
-      for (i32 j = 0; j < input_columns.size(); ++j) {
-        if (config_.input_column_types[j] == proto::ColumnType::Video) {
-          const Frame* frame = input_columns[j][i].as_const_frame();
-          np::dtype dtype = np::dtype::get_builtin<uint8_t>();
-          u32 dtype_size;
-          if (frame->type == FrameType::U8) {
-            dtype = np::dtype::get_builtin<uint8_t>();
-            dtype_size = 1;
-          } else if (frame->type == FrameType::F32) {
-            dtype = np::dtype::get_builtin<float>();
-            dtype_size = 4;
-          } else if (frame->type == FrameType::F64) {
-            dtype = np::dtype::get_builtin<double>();
-            dtype_size = 8;
-          }
-          np::ndarray frame_np =
-              np::from_data(frame->data, dtype,
-                            py::make_tuple(frame->height(), frame->width(),
-                                           frame->channels()),
-                            py::make_tuple(frame->width() * frame->channels() * dtype_size,
-                                           frame->channels() * dtype_size, dtype_size),
-                            py::object());
-          cols.append(frame_np);
-        } else {
-          cols.append(py::str((char const*)input_columns[j][i].buffer,
-                              input_columns[j][i].size));
-        }
-      }
-
-      py::list out_cols = py::extract<py::list>(kernel.attr("execute")(cols));
-      LOG_IF(FATAL, py::len(out_cols) != output_columns.size())
-          << "Incorrect number of output columns. Expected "
-          << output_columns.size();
-
-      for (i32 j = 0; j < output_columns.size(); ++j) {
-        if (config_.output_column_types[j] == proto::ColumnType::Video) {
-          np::ndarray frame_np = py::extract<np::ndarray>(out_cols[j]);
-          FrameType frame_type;
-          {
-            np::dtype dtype = frame_np.get_dtype();
-            if (dtype == np::dtype::get_builtin<uint8_t>()) {
-              frame_type = FrameType::U8;
-            } else if (dtype == np::dtype::get_builtin<f32>()) {
-              frame_type = FrameType::F32;
-            } else if (dtype == np::dtype::get_builtin<f64>()) {
-              frame_type = FrameType::F64;
-            } else {
-              LOG(FATAL) << "Invalid numpy dtype: "
-                         << py::extract<char const*>(py::str(dtype));
-            }
-          }
-          i32 ndim = frame_np.get_nd();
-          if (ndim > 3) {
-            LOG(FATAL) << "Invalid number of dimensions (must be less than 4): "
-                       << ndim;
-          }
-          std::vector<i32> shapes;
-          std::vector<i32> strides;
-          for (int n = 0; n < ndim; ++n) {
-            shapes.push_back(frame_np.shape(n));
-            strides.push_back(frame_np.strides(n));
-          }
-          FrameInfo frame_info(shapes, frame_type);
-          Frame* frame = new_frame(CPU_DEVICE, frame_info);
-          const char* frame_data = frame_np.get_data();
-
-          if (ndim == 3) {
-            assert(strides[1] % strides[2] == 0);
-            for (int i = 0; i < shapes[0]; ++i) {
-              u64 offset = strides[0] * i;
-              memcpy(frame->data + offset, frame_data + offset,
-                     shapes[2] * shapes[1] * strides[2]);
-            }
-          } else {
-            LOG(FATAL) << "Can not support ndim != 3.";
-          }
-          insert_frame(output_columns[j], frame);
-        } else {
-          std::string field = py::extract<std::string>(out_cols[j]);
-          size_t size = field.size();
-          u8* buf = new_buffer(CPU_DEVICE, size);
-          memcpy_buffer(buf, CPU_DEVICE, (u8*)field.data(), CPU_DEVICE, size);
-          insert_element(output_columns[j], buf, size);
-        }
-      }
-    }
-  } catch (py::error_already_set& e) {
-    LOG(FATAL) << handle_pyerror();
-  }
-
-  PyGILState_Release(gstate);
-}
-
-void PythonKernel::new_stream(const std::vector<u8>& args) {
-  PyGILState_STATE gstate = PyGILState_Ensure();
-
-  try {
-    py::object main = py::import("__main__");
-    py::object kernel = main.attr(py::str(kernel_name_));
-
-    py::object main_namespace = main.attr("__dict__");
-    main.attr("args_str") = py::str(reinterpret_cast<const char*>(args.data()),
-                                    args.size());
-    std::string pycode = tfm::format(
-        "import pickle\n"
-        "if len(args_str) == 0:\n"
-        "  args = None\n"
-        "else:\n"
-        "  args = pickle.loads(args_str)\n"
-        "%s.new_stream(args)",
-        kernel_name_);
-    py::exec(pycode.c_str(), main_namespace);
-  } catch (py::error_already_set& e) {
-    LOG(FATAL) << handle_pyerror();
-  }
-
-  PyGILState_Release(gstate);
-}
-
-void PythonKernel::execute(const BatchedElements& input_columns,
-                           BatchedElements& output_columns) {
-  if (can_batch_) {
-    batched_python_execute(input_columns, output_columns);
-  } else {
-    single_python_execute(input_columns, output_columns);
-  }
-
-}
-
 }

--- a/scanner/engine/python_kernel.h
+++ b/scanner/engine/python_kernel.h
@@ -3,9 +3,6 @@
 #include "scanner/util/memory.h"
 #include "scanner/metadata.pb.h"
 
-#include <boost/python.hpp>
-#include <boost/python/numpy.hpp>
-
 namespace scanner {
 
 class PythonKernel : public BatchedKernel {
@@ -26,10 +23,6 @@ class PythonKernel : public BatchedKernel {
   void reset() override;
 
  private:
-  void batched_python_execute(const BatchedElements& input_columns,
-                              BatchedElements& output_columns);
-  void single_python_execute(const BatchedElements& input_columns,
-                             BatchedElements& output_columns);
   KernelConfig config_;
   DeviceHandle device_;
   bool can_batch_;

--- a/scanner/engine/rpc.proto
+++ b/scanner/engine/rpc.proto
@@ -152,7 +152,7 @@ message PythonKernelRegistration {
   string op_name = 1;
   DeviceType device_type = 2;
   string kernel_str = 3;
-  string pickled_config = 4;
+  bytes pickled_config = 4;
   int32 batch_size = 5;
 }
 

--- a/scanner/engine/worker.cpp
+++ b/scanner/engine/worker.cpp
@@ -35,6 +35,8 @@
 #include <netdb.h>
 #include <sys/socket.h>
 #include <omp.h>
+#include <pybind11/embed.h>
+
 
 // For avcodec_register_all()... should go in software video with global mutex
 extern "C" {
@@ -44,6 +46,7 @@ extern "C" {
 using storehouse::StoreResult;
 using storehouse::WriteFile;
 using storehouse::RandomReadFile;
+namespace py = pybind11;
 
 namespace scanner {
 namespace internal {
@@ -482,9 +485,6 @@ WorkerImpl::WorkerImpl(DatabaseParameters& db_params,
 
   storage_ =
       storehouse::StorageBackend::make_from_config(db_params_.storage_config);
-
-  // Set up Python runtime if any kernels need it
-  Py_Initialize();
 
   // Processes jobs in the background
   start_job_processor();

--- a/scanner/engine/worker.h
+++ b/scanner/engine/worker.h
@@ -23,7 +23,6 @@
 #include <grpc/support/log.h>
 #include <atomic>
 #include <thread>
-#include <boost/python.hpp>
 
 namespace scanner {
 namespace internal {

--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -124,9 +124,3 @@ if (HALIDE_TARGETS)
     add_dependencies(stdlib scanner_halide)
   endif()
 endif()
-
-find_package(Boost COMPONENTS thread program_options regex python REQUIRED)
-target_link_libraries(stdlib PUBLIC
-  "${Boost_LIBRAIRES}"
-  "${Boost_LIBRARY_DIRS}/libboost_numpy.so")
-target_include_directories(stdlib PUBLIC "${Boost_INCLUDE_DIRS}")

--- a/tests/test_py_batch_kernel.py
+++ b/tests/test_py_batch_kernel.py
@@ -15,7 +15,7 @@ class TestPyBatchKernel(scannerpy.Kernel):
         point.y = 5
         input_count = len(input_columns[0])
         column_count = len(input_columns)
-        return [[point.SerializeToString() for _ in xrange(input_count)]
-                 for _ in xrange(column_count)]
+        return [[point.SerializeToString() for _ in range(input_count)]
+                 for _ in range(column_count)]
 
 KERNEL = TestPyBatchKernel


### PR DESCRIPTION
Biggest change is dropping Boost (we're now Boost-Free™!) in favor of pybind11. This simplified the bindings considerably, since pybind comes with niceties for thing slike converting std::vector automatically into Python lists. Also got rid of GILRelease since the same concept exists in pybind. Pybind will be in the deps.sh script in place of Boost.

In terms of Python 3 compatibility, I've updated all the Python scripts in the repository. For the bindings, the major change is that we now have to carefully distinguish between unicode strings and byte strings (including in our protobufs, i.e. bytes vs. string). For example, Storehouse read methods return bytes now.

I haven't built the base images yet, as @apoms I want your approval before doing so (since it would break all non-py3 builds). I've confirmed that this branch passes all the tests on my GCE machine.

