### PR TITLE
fix: fix error in example pose detection

### DIFF
--- a/examples/apps/pose_detection/main.py
+++ b/examples/apps/pose_detection/main.py
@@ -61,7 +61,7 @@ job = Job(
         output: movie_name + '_drawn_poses',
 })
 [drawn_poses_table] = db.run(output=output, jobs=[job], work_packet_size=8, io_packet_size=64,
-                             pipeline_instances_per_node=pipelineinstances,
+                             pipeline_instances_per_node=pipeline_instances,
                              force=True)
 
 print('Writing output video...')


### PR DESCRIPTION
There is an typo in line 64 of the pose detection example which causes the error while running the main.py.