### PR TITLE
Add initial Python-side type system for ops

### DIFF
--- a/python/scannerpy/__init__.py
+++ b/python/scannerpy/__init__.py
@@ -1,6 +1,7 @@
 from scannerpy.common import ScannerException, DeviceType, DeviceHandle, FrameType, ColumnType
 from scannerpy.job import Job
-from scannerpy.database import Database, ProtobufGenerator, start_master, start_worker
+from scannerpy.database import Database, start_master, start_worker
 from scannerpy.config import Config
 from scannerpy.kernel import Kernel, KernelConfig
 from scannerpy.op import register_python_op
+from scannerpy.protobufs import protobufs

--- a/python/scannerpy/column.py
+++ b/python/scannerpy/column.py
@@ -261,6 +261,10 @@ class Column(object):
                 self._video_descriptor.channels, dtype)
             return self._load(fn=parser_fn, rows=rows, workers=workers)
         else:
+            # Use a deserializer function if provided.
+            # If not, use a type if provided.
+            # If not, attempt to determine the type from the column's table descriptor.
+            # If that doesn't work, then assume no deserialization function, and return bytes.
             if fn is None:
                 if ty is None:
                     type_name = self._descriptor.type_name

--- a/python/scannerpy/common.py
+++ b/python/scannerpy/common.py
@@ -2,7 +2,6 @@ import numpy as np
 import enum
 from collections import defaultdict
 
-
 class ScannerException(Exception):
     pass
 
@@ -42,7 +41,7 @@ class ColumnType(enum.Enum):
     @staticmethod
     def to_proto(protobufs, ty):
         if ty == ColumnType.Blob:
-            return protobufs.Other
+            return protobufs.Bytes
         elif ty == ColumnType.Video:
             return protobufs.Video
         else:

--- a/python/scannerpy/kernel.py
+++ b/python/scannerpy/kernel.py
@@ -15,7 +15,6 @@ class KernelConfig(object):
 class Kernel(object):
     def __init__(self, config):
         self.config = config
-        self.protobufs = config.protobufs
 
     def close(self):
         pass
@@ -36,16 +35,12 @@ def python_kernel_fn(n, recv_conn, send_conn, p_conn1, p_conn2):
   import traceback
   import os
   from scannerpy import Config, DeviceType, DeviceHandle, KernelConfig
-  from scannerpy.protobuf_generator import ProtobufGenerator
 
   # Close parent connections
   p_conn1.close()
   p_conn2.close()
   try:
-    user_config = pickle.loads(n['user_config_str'])
-    protobufs = ProtobufGenerator(user_config)
     kernel_config = KernelConfig(cloudpickle.loads(n['config']))
-    kernel_config.protobufs = protobufs
     kernel = cloudpickle.loads(n['kernel_code'])(kernel_config)
     while True:
       try:

--- a/python/scannerpy/op.py
+++ b/python/scannerpy/op.py
@@ -333,11 +333,8 @@ def register_python_op(name: str = None,
             elif typ == bytes:
                 column_type = ColumnType.Blob
             else:
+                # For now, all non-FrameType types are equivalent to bytes.
                 column_type = ColumnType.Blob
-                # raise ScannerException(
-                #     ('Invalid type annotation specified for input {:s}. Must '
-                #      'specify an annotation of type "bytes" or '
-                #      '"FrameType".').format(param_name))
             return column_type, typ
 
         # Analyze exec_fn parameters to determine the input types

--- a/python/scannerpy/partitioner.py
+++ b/python/scannerpy/partitioner.py
@@ -1,4 +1,5 @@
 from scannerpy.common import *
+from scannerpy.protobufs import protobufs
 
 DEFAULT_GROUP_SIZE = 250
 
@@ -15,10 +16,10 @@ class TaskPartitioner:
         return self.strided(1, group_size=group_size)
 
     def strided(self, stride, group_size=DEFAULT_GROUP_SIZE):
-        args = self._db.protobufs.StridedPartitionerArgs()
+        args = protobufs.StridedPartitionerArgs()
         args.stride = stride
         args.group_size = group_size
-        sampling_args = self._db.protobufs.SamplingArgs()
+        sampling_args = protobufs.SamplingArgs()
         sampling_args.sampling_function = 'Strided'
         sampling_args.sampling_args = args.SerializeToString()
         return sampling_args
@@ -30,11 +31,11 @@ class TaskPartitioner:
         return self.strided_ranges(intervals, 1)
 
     def gather(self, groups):
-        args = self._db.protobufs.GatherSamplerArgs()
+        args = protobufs.GatherSamplerArgs()
         for rows in groups:
             gather_group = args.groups_add()
             gather_group.rows[:] = rows
-        sampling_args = self._db.protobufs.SamplingArgs()
+        sampling_args = protobufs.SamplingArgs()
         sampling_args.sampling_function = 'Gather'
         sampling_args.sampling_args = args.SerializeToString()
         return sampling_args
@@ -43,12 +44,12 @@ class TaskPartitioner:
         return self.strided_ranges([(start, end)], stride)
 
     def strided_ranges(self, intervals, stride):
-        args = self._db.protobufs.StridedRangePartitionerArgs()
+        args = protobufs.StridedRangePartitionerArgs()
         args.stride = stride
         for start, end in intervals:
             args.starts.append(start)
             args.ends.append(end)
-        sampling_args = self._db.protobufs.SamplingArgs()
+        sampling_args = protobufs.SamplingArgs()
         sampling_args.sampling_function = 'StridedRange'
         sampling_args.sampling_args = args.SerializeToString()
         return sampling_args

--- a/python/scannerpy/profiler.py
+++ b/python/scannerpy/profiler.py
@@ -6,7 +6,7 @@ import tarfile
 import os
 
 from scannerpy.common import *
-
+from scannerpy.protobufs import protobufs
 
 def read_advance(fmt, buf, offset):
     new_offset = offset + struct.calcsize(fmt)
@@ -31,7 +31,7 @@ class Profiler:
 
     def __init__(self, db, job_id, load_threads=8, subsample=None):
         self._storage = db._storage
-        job = db._load_descriptor(db.protobufs.BulkJobDescriptor,
+        job = db._load_descriptor(protobufs.BulkJobDescriptor,
                                   'jobs/{}/descriptor.bin'.format(job_id))
 
         def get_prof(path, worker=True):

--- a/python/scannerpy/protobufs.py
+++ b/python/scannerpy/protobufs.py
@@ -16,7 +16,7 @@ from google.protobuf.descriptor import FieldDescriptor
 
 
 class ProtobufGenerator:
-    def __init__(self, cfg):
+    def __init__(self):
         self._mods = []
         for mod in [
                 misc_types, rpc_types, grpc_types, metadata_types,
@@ -109,3 +109,5 @@ def python_to_proto(protos, proto_name, obj):
         return proto_obj
 
     return create_obj(args_proto, p, obj).SerializeToString()
+
+protobufs = ProtobufGenerator()

--- a/python/scannerpy/sampler.py
+++ b/python/scannerpy/sampler.py
@@ -1,4 +1,5 @@
 from scannerpy.common import *
+from scannerpy.protobufs import protobufs
 
 DEFAULT_TASK_SIZE = 125
 
@@ -13,7 +14,7 @@ class Sampler:
 
     def All(self, input):
         def arg_builder():
-            sampling_args = self._db.protobufs.SamplingArgs()
+            sampling_args = protobufs.SamplingArgs()
             sampling_args.sampling_function = "All"
             return sampling_args
         return self._db.ops.Sample(
@@ -23,9 +24,9 @@ class Sampler:
 
     def Stride(self, input, stride=None):
         def arg_builder(stride=stride):
-            args = self._db.protobufs.StridedSamplerArgs()
+            args = protobufs.StridedSamplerArgs()
             args.stride = stride
-            sampling_args = self._db.protobufs.SamplingArgs()
+            sampling_args = protobufs.SamplingArgs()
             sampling_args.sampling_function = "Strided"
             sampling_args.sampling_args = args.SerializeToString()
             return sampling_args
@@ -43,9 +44,9 @@ class Sampler:
 
     def Gather(self, input, rows=None):
         def arg_builder(rows=rows):
-            args = self._db.protobufs.GatherSamplerArgs()
+            args = protobufs.GatherSamplerArgs()
             args.rows[:] = rows
-            sampling_args = self._db.protobufs.SamplingArgs()
+            sampling_args = protobufs.SamplingArgs()
             sampling_args.sampling_function = 'Gather'
             sampling_args.sampling_args = args.SerializeToString()
             return sampling_args
@@ -61,12 +62,12 @@ class Sampler:
 
     def StridedRanges(self, input, intervals=None, stride=None):
         def arg_builder(intervals=intervals, stride=stride):
-            args = self._db.protobufs.StridedRangeSamplerArgs()
+            args = protobufs.StridedRangeSamplerArgs()
             args.stride = stride
             for start, end in intervals:
                 args.starts.append(start)
                 args.ends.append(end)
-            sampling_args = self._db.protobufs.SamplingArgs()
+            sampling_args = protobufs.SamplingArgs()
             sampling_args.sampling_function = "StridedRanges"
             sampling_args.sampling_args = args.SerializeToString()
             return sampling_args
@@ -78,9 +79,9 @@ class Sampler:
 
     def RepeatNull(self, input, spacing=None):
         def arg_builder(spacing=spacing):
-            args = self._db.protobufs.SpaceNullSamplerArgs()
+            args = protobufs.SpaceNullSamplerArgs()
             args.spacing = spacing
-            sampling_args = self._db.protobufs.SamplingArgs()
+            sampling_args = protobufs.SamplingArgs()
             sampling_args.sampling_function = "SpaceNull"
             sampling_args.sampling_args = args.SerializeToString()
             return sampling_args
@@ -93,9 +94,9 @@ class Sampler:
 
     def Repeat(self, input, spacing=None):
         def arg_builder(spacing=spacing):
-            args = self._db.protobufs.SpaceRepeatSamplerArgs()
+            args = protobufs.SpaceRepeatSamplerArgs()
             args.spacing = spacing
-            sampling_args = self._db.protobufs.SamplingArgs()
+            sampling_args = protobufs.SamplingArgs()
             sampling_args.sampling_function = "SpaceRepeat"
             sampling_args.sampling_args = args.SerializeToString()
             return sampling_args

--- a/python/scannerpy/sink.py
+++ b/python/scannerpy/sink.py
@@ -4,7 +4,7 @@ import copy
 
 from scannerpy.common import *
 from scannerpy.op import OpColumn
-from scannerpy.protobuf_generator import python_to_proto
+from scannerpy.protobufs import python_to_proto, protobufs
 
 
 class Sink:
@@ -50,7 +50,7 @@ class Sink:
         return self._inputs
 
     def to_proto(self, indices):
-        e = self._db.protobufs.Op()
+        e = protobufs.Op()
         e.name = self._name
         e.is_sink = True
 
@@ -70,7 +70,7 @@ class Sink:
                 if len(sink_info.protobuf_name) > 0:
                     proto_name = sink_info.protobuf_name
                     e.kernel_args = python_to_proto(
-                        self._db.protobufs, proto_name, self._args)
+                        protobufs, proto_name, self._args)
                 else:
                     e.kernel_args = self._args
         else:

--- a/python/scannerpy/source.py
+++ b/python/scannerpy/source.py
@@ -3,7 +3,7 @@ import copy
 
 from scannerpy.common import *
 from scannerpy.op import OpColumn
-from scannerpy.protobuf_generator import python_to_proto
+from scannerpy.protobufs import python_to_proto, protobufs
 
 
 class Source:
@@ -42,7 +42,7 @@ class Source:
             return tuple(self._outputs)
 
     def to_proto(self, indices):
-        e = self._db.protobufs.Op()
+        e = protobufs.Op()
         e.name = self._name
         e.is_source = True
 
@@ -59,7 +59,7 @@ class Source:
                 source_info = self._db._get_source_info(self._name)
                 if len(source_info.protobuf_name) > 0:
                     proto_name = source_info.protobuf_name
-                    e.kernel_args = python_to_proto(self._db.protobufs,
+                    e.kernel_args = python_to_proto(protobufs,
                                                     proto_name, self._args)
                 else:
                     e.kernel_args = self._args

--- a/python/scannerpy/stdlib/readers.py
+++ b/python/scannerpy/stdlib/readers.py
@@ -4,19 +4,6 @@ import struct
 from scannerpy.stdlib.poses import Pose
 
 
-def bboxes(buf, protobufs):
-    (num_bboxes, ) = struct.unpack("=Q", buf[:8])
-    buf = buf[8:]
-    bboxes = []
-    for i in range(num_bboxes):
-        (bbox_size, ) = struct.unpack("=Q", buf[:8])
-        buf = buf[8:]
-        box = protobufs.BoundingBox()
-        box.ParseFromString(buf[:bbox_size])
-        buf = buf[bbox_size:]
-        bboxes.append(box)
-    return bboxes
-
 
 def poses(buf, protobufs):
     if len(buf) == 4:
@@ -68,14 +55,14 @@ def array(ty, size=None):
     return parser
 
 
-def image(buf, protobufs):
+def image(buf):
     import cv2
     return cv2.imdecode(
         np.frombuffer(buf, dtype=np.dtype(np.uint8)), cv2.IMREAD_COLOR)
 
 
 def raw_frame_gen(shape0, shape1, shape2, typ):
-    def parser(bufs, protobufs):
+    def parser(bufs):
         output = np.frombuffer(bufs, dtype=typ)
         return output.reshape((shape0, shape1, shape2))
 

--- a/python/scannerpy/streams.py
+++ b/python/scannerpy/streams.py
@@ -1,13 +1,14 @@
 import scannerpy.op
 
 from scannerpy.common import *
+from scannerpy.protobufs import protobufs
 from typing import Sequence, Union, Tuple, Optional
 
 class StreamsGenerator:
     r"""Provides Ops for sampling elements from streams.
 
     The methods of this class construct Scanner Ops that enable selecting
-    subsets of the elements in a stream to produce new streams. 
+    subsets of the elements in a stream to produce new streams.
 
     This class should not be constructed directly, but accessed via a Database
     object like:
@@ -76,7 +77,7 @@ class StreamsGenerator:
           The sampled stream.
         """
         def arg_builder():
-            sampling_args = self._db.protobufs.SamplingArgs()
+            sampling_args = protobufs.SamplingArgs()
             sampling_args.sampling_function = "All"
             return sampling_args
         return self._db.ops.Sample(
@@ -104,9 +105,9 @@ class StreamsGenerator:
           The sampled stream.
         """
         def arg_builder(stride=stride):
-            args = self._db.protobufs.StridedSamplerArgs()
+            args = protobufs.StridedSamplerArgs()
             args.stride = stride
-            sampling_args = self._db.protobufs.SamplingArgs()
+            sampling_args = protobufs.SamplingArgs()
             sampling_args.sampling_function = "Strided"
             sampling_args.sampling_args = args.SerializeToString()
             return sampling_args
@@ -140,11 +141,11 @@ class StreamsGenerator:
           The sampled stream.
         """
         def arg_builder(start=start, end=end):
-            args = self._db.protobufs.StridedRangeSamplerArgs()
+            args = protobufs.StridedRangeSamplerArgs()
             args.stride = 1
             args.starts.append(start)
             args.ends.append(end)
-            sampling_args = self._db.protobufs.SamplingArgs()
+            sampling_args = protobufs.SamplingArgs()
             sampling_args.sampling_function = "StridedRanges"
             sampling_args.sampling_args = args.SerializeToString()
             return sampling_args
@@ -183,12 +184,12 @@ class StreamsGenerator:
         db.streams.Ranges(input=input, intervals=[(0, 11), (100, 201)])
         """
         def arg_builder(intervals=intervals):
-            args = self._db.protobufs.StridedRangeSamplerArgs()
+            args = protobufs.StridedRangeSamplerArgs()
             args.stride = 1
             for start, end in intervals:
                 args.starts.append(start)
                 args.ends.append(end)
-            sampling_args = self._db.protobufs.SamplingArgs()
+            sampling_args = protobufs.SamplingArgs()
             sampling_args.sampling_function = "StridedRanges"
             sampling_args.sampling_args = args.SerializeToString()
             return sampling_args
@@ -226,11 +227,11 @@ class StreamsGenerator:
           The sampled stream.
         """
         def arg_builder(start=start, end=end, stride=stride):
-            args = self._db.protobufs.StridedRangeSamplerArgs()
+            args = protobufs.StridedRangeSamplerArgs()
             args.stride = stride
             args.starts.append(start)
             args.ends.append(end)
-            sampling_args = self._db.protobufs.SamplingArgs()
+            sampling_args = protobufs.SamplingArgs()
             sampling_args.sampling_function = "StridedRanges"
             sampling_args.sampling_args = args.SerializeToString()
             return sampling_args
@@ -268,12 +269,12 @@ class StreamsGenerator:
           The sampled stream.
         """
         def arg_builder(intervals=intervals, stride=stride):
-            args = self._db.protobufs.StridedRangeSamplerArgs()
+            args = protobufs.StridedRangeSamplerArgs()
             args.stride = stride
             for start, end in intervals:
                 args.starts.append(start)
                 args.ends.append(end)
-            sampling_args = self._db.protobufs.SamplingArgs()
+            sampling_args = protobufs.SamplingArgs()
             sampling_args.sampling_function = "StridedRanges"
             sampling_args.sampling_args = args.SerializeToString()
             return sampling_args
@@ -304,9 +305,9 @@ class StreamsGenerator:
           The sampled stream.
         """
         def arg_builder(rows=rows):
-            args = self._db.protobufs.GatherSamplerArgs()
+            args = protobufs.GatherSamplerArgs()
             args.rows[:] = rows
-            sampling_args = self._db.protobufs.SamplingArgs()
+            sampling_args = protobufs.SamplingArgs()
             sampling_args.sampling_function = 'Gather'
             sampling_args.sampling_args = args.SerializeToString()
             return sampling_args
@@ -335,9 +336,9 @@ class StreamsGenerator:
           The sampled stream.
         """
         def arg_builder(spacing=spacing):
-            args = self._db.protobufs.SpaceNullSamplerArgs()
+            args = protobufs.SpaceNullSamplerArgs()
             args.spacing = spacing
-            sampling_args = self._db.protobufs.SamplingArgs()
+            sampling_args = protobufs.SamplingArgs()
             sampling_args.sampling_function = "SpaceNull"
             sampling_args.sampling_args = args.SerializeToString()
             return sampling_args
@@ -366,9 +367,9 @@ class StreamsGenerator:
           The sampled stream.
         """
         def arg_builder(spacing=spacing):
-            args = self._db.protobufs.SpaceRepeatSamplerArgs()
+            args = protobufs.SpaceRepeatSamplerArgs()
             args.spacing = spacing
-            sampling_args = self._db.protobufs.SamplingArgs()
+            sampling_args = protobufs.SamplingArgs()
             sampling_args.sampling_function = "SpaceRepeat"
             sampling_args.sampling_args = args.SerializeToString()
             return sampling_args

--- a/python/scannerpy/table.py
+++ b/python/scannerpy/table.py
@@ -4,6 +4,7 @@ import struct
 from timeit import default_timer as now
 
 from scannerpy.common import *
+from scannerpy.protobufs import protobufs
 from scannerpy.column import Column
 
 
@@ -40,9 +41,9 @@ class Table:
             self._video_descriptors = []
             for c in self._descriptor.columns:
                 video_descriptor = None
-                if c.type == self._db.protobufs.Video:
+                if c.type == protobufs.Video:
                     video_descriptor = self._db._load_descriptor(
-                        self._db.protobufs.VideoDescriptor,
+                        protobufs.VideoDescriptor,
                         'tables/{:d}/{:d}_0_video_metadata.bin'.format(
                             self._id, c.id))
                 self._video_descriptors.append(video_descriptor)
@@ -56,7 +57,7 @@ class Table:
         self._need_descriptor()
         if self._descriptor.job_id != -1:
             self._job = self._db._load_descriptor(
-                self._db.protobufs.JobDescriptor,
+                protobufs.JobDescriptor,
                 'jobs/{}/descriptor.bin'.format(self._descriptor.job_id))
             self._task = None
             for task in self._job.tasks:

--- a/python/scannerpy/types.py
+++ b/python/scannerpy/types.py
@@ -42,6 +42,7 @@ _register_type(bytes, "Bytes", lambda x: x, lambda x: x)
 _register_type(Any, "Any", pickle.dumps, pickle.loads)
 _register_type(FrameType, "FrameType", lambda x: x, lambda x: x)
 
+# TODO: document this
 def register_type(cls):
     name = cls.__name__
     _register_type(cls, name, cls.serializer, cls.deserializer)

--- a/python/scannerpy/types.py
+++ b/python/scannerpy/types.py
@@ -1,0 +1,85 @@
+from typing import Any
+from attr import attrs, attrib
+from scannerpy.common import FrameType, ScannerException
+from scannerpy.protobufs import protobufs
+import pickle
+from typing import NewType
+import numpy as np
+from typing import Generic, TypeVar
+import struct
+
+PYTHON_TYPE_REGISTRY = {}
+
+@attrs(frozen=True)
+class ScannerTypeInfo:
+    type = attrib()
+    cpp_name = attrib()
+    serializer = attrib()
+    deserializer = attrib()
+
+def _register_type(ty, cpp_name, serializer, deserializer):
+    global PYTHON_TYPE_REGISTRY
+    PYTHON_TYPE_REGISTRY[ty] = ScannerTypeInfo(
+        type=ty,
+        cpp_name=cpp_name,
+        serializer=serializer,
+        deserializer=deserializer)
+
+def get_type_info(ty):
+    global PYTHON_TYPE_REGISTRY
+    if not ty in PYTHON_TYPE_REGISTRY:
+        raise ScannerException("Type `{}` has not been registered with Scanner".format(ty))
+    return PYTHON_TYPE_REGISTRY[ty]
+
+def get_type_info_cpp(cpp_name):
+    global PYTHON_TYPE_REGISTRY
+    for ty in PYTHON_TYPE_REGISTRY.values():
+        if ty.cpp_name == cpp_name:
+            return ty
+    raise ScannerException("Type `{}` has not been registered with Scanner".format(cpp_name))
+
+_register_type(bytes, "Bytes", lambda x: x, lambda x: x)
+_register_type(Any, "Any", pickle.dumps, pickle.loads)
+_register_type(FrameType, "FrameType", lambda x: x, lambda x: x)
+
+def register_type(cls):
+    name = cls.__name__
+    _register_type(cls, name, cls.serializer, cls.deserializer)
+    return cls
+
+
+def ProtoList(name, proto):
+    class ProtoList:
+        def serializer(proto_list):
+            s = struct.pack('=Q', len(proto_list))
+            for element in proto_list:
+                serialized = element.SerializeToString()
+                s += struct.pack('=Q', len(serialized))
+                s += serialized
+            return s
+
+        def deserializer(buf):
+            (N, ) = struct.unpack("=Q", buf[:8])
+            buf = buf[8:]
+            elements = []
+            for i in range(N):
+                (serialized_size, ) = struct.unpack("=Q", buf[:8])
+                buf = buf[8:]
+                element = proto()
+                element.ParseFromString(buf[:serialized_size])
+                buf = buf[serialized_size:]
+                elements.append(element)
+            return element
+
+    ProtoList.__name__ = name
+    return ProtoList
+
+BboxList = register_type(ProtoList('BboxList', protobufs.BoundingBox))
+
+@register_type
+class Histogram:
+    def serializer(buf):
+        raise NotImplemented
+
+    def deserializer(buf):
+        return np.split(np.frombuffer(buf, dtype=np.dtype(np.int32)), 3)

--- a/scanner/api/op.cpp
+++ b/scanner/api/op.cpp
@@ -39,6 +39,7 @@ OpRegistration::OpRegistration(const OpBuilder& builder) {
     col.set_id(i++);
     col.set_name(std::get<0>(name_type));
     col.set_type(std::get<1>(name_type));
+    col.set_type_name((std::get<2>(name_type)));
     output_columns.push_back(col);
   }
   bool can_stencil = builder.can_stencil_;

--- a/scanner/api/op.h
+++ b/scanner/api/op.h
@@ -51,7 +51,7 @@ class OpBuilder {
   }
 
   OpBuilder& input(const std::string& name,
-                   ColumnType type = ColumnType::Other) {
+                   ColumnType type = ColumnType::Bytes) {
     if (variadic_inputs_) {
       LOG(FATAL) << "Op " << name_ << " cannot have both fixed and variadic "
                  << "inputs";
@@ -65,8 +65,9 @@ class OpBuilder {
   }
 
   OpBuilder& output(const std::string& name,
-                    ColumnType type = ColumnType::Other) {
-    output_columns_.push_back(std::make_tuple(name, type));
+                    ColumnType type = ColumnType::Bytes,
+                    std::string type_name = "") {
+    output_columns_.push_back(std::make_tuple(name, type, type_name));
     return *this;
   }
 
@@ -110,7 +111,7 @@ class OpBuilder {
   std::string name_;
   bool variadic_inputs_;
   std::vector<std::tuple<std::string, ColumnType>> input_columns_;
-  std::vector<std::tuple<std::string, ColumnType>> output_columns_;
+  std::vector<std::tuple<std::string, ColumnType, std::string>> output_columns_;
   bool can_stencil_;
   std::vector<int> preferred_stencil_ = {0};
   bool has_bounded_state_;

--- a/scanner/api/sink.h
+++ b/scanner/api/sink.h
@@ -123,7 +123,7 @@ class SinkBuilder {
   }
 
   SinkBuilder& input(const std::string& name,
-                   ColumnType type = ColumnType::Other) {
+                   ColumnType type = ColumnType::Bytes) {
     if (variadic_inputs_) {
       LOG(FATAL) << "Sink " << name_ << " cannot have both fixed and variadic "
                  << "inputs";

--- a/scanner/api/source.h
+++ b/scanner/api/source.h
@@ -103,7 +103,7 @@ class SourceBuilder {
       constructor_(constructor) {}
 
   SourceBuilder& output(const std::string& name,
-                    ColumnType type = ColumnType::Other) {
+                    ColumnType type = ColumnType::Bytes) {
     if (output_columns_.size() > 0) {
       LOG(FATAL) << "Sources can only have one output column.";
     }

--- a/scanner/engine/column_source.cpp
+++ b/scanner/engine/column_source.cpp
@@ -479,7 +479,7 @@ void ColumnSource::read(const std::vector<ElementArgs>& element_args,
   RowIntervals intervals = slice_into_row_intervals(table_meta, rows);
   size_t num_items = intervals.item_ids.size();
 
-  ColumnType column_type = ColumnType::Other;
+  ColumnType column_type = ColumnType::Bytes;
   if (table_meta.column_type(col_id) == ColumnType::Video) {
     column_type = ColumnType::Video;
     // video frame column

--- a/scanner/engine/ingest.cpp
+++ b/scanner/engine/ingest.cpp
@@ -186,7 +186,7 @@ bool parse_and_write_video(storehouse::StorageBackend* storage,
     Column* index_col = table_desc.add_columns();
     index_col->set_name(index_column_name());
     index_col->set_id(0);
-    index_col->set_type(ColumnType::Other);
+    index_col->set_type(ColumnType::Bytes);
 
     Column* frame_col = table_desc.add_columns();
     frame_col->set_name(frame_column_name());
@@ -392,7 +392,7 @@ bool parse_video_inplace(storehouse::StorageBackend* storage,
     Column* index_col = table_desc.add_columns();
     index_col->set_name(index_column_name());
     index_col->set_id(0);
-    index_col->set_type(ColumnType::Other);
+    index_col->set_type(ColumnType::Bytes);
 
     Column* frame_col = table_desc.add_columns();
     frame_col->set_name(frame_column_name());

--- a/scanner/engine/master.cpp
+++ b/scanner/engine/master.cpp
@@ -376,7 +376,7 @@ void MasterServerImpl::NewTableHandler(
     proto::Column* col = table_desc.add_columns();
     col->set_id(i);
     col->set_name(columns[i]);
-    col->set_type(proto::ColumnType::Other);
+    col->set_type(proto::ColumnType::Bytes);
   }
 
   table_desc.add_end_rows(rows.size());
@@ -759,6 +759,7 @@ void MasterServerImpl::RegisterOpHandler(
       col.set_id(i++);
       col.set_name(c.name());
       col.set_type(c.type());
+      col.set_type_name(c.type_name());
       input_columns.push_back(col);
     }
     std::vector<Column> output_columns;
@@ -768,6 +769,7 @@ void MasterServerImpl::RegisterOpHandler(
       col.set_id(i++);
       col.set_name(c.name());
       col.set_type(c.type());
+      col.set_type_name(c.type_name());
       output_columns.push_back(col);
     }
     bool can_stencil = op_registration->can_stencil();
@@ -812,7 +814,6 @@ void MasterServerImpl::RegisterPythonKernelHandler(
     const std::string& op_name = python_kernel->op_name();
     DeviceType device_type = python_kernel->device_type();
     const std::string& kernel_code = python_kernel->kernel_code();
-    const std::string& pickled_config = python_kernel->pickled_config();
     const int batch_size = python_kernel->batch_size();
 
     // Set all input and output columns to be CPU
@@ -837,10 +838,10 @@ void MasterServerImpl::RegisterPythonKernelHandler(
     }
 
     // Create a kernel builder function
-    auto constructor = [op_name, kernel_code, pickled_config,
-                        can_batch, can_stencil](const KernelConfig& config) {
-      return new PythonKernel(config, op_name, kernel_code, pickled_config,
-                              can_batch, can_stencil);
+    auto constructor = [op_name, kernel_code, can_batch,
+                        can_stencil](const KernelConfig& config) {
+      return new PythonKernel(config, op_name, kernel_code, can_batch,
+                              can_stencil);
     };
 
     // Create a new kernel factory

--- a/scanner/engine/python.cpp
+++ b/scanner/engine/python.cpp
@@ -143,7 +143,7 @@ namespace scanner {
       .value("CPU", DeviceType::CPU);
 
     py::enum_<proto::ColumnType>(m, "ColumnType")
-      .value("Other", ColumnType::Other)
+      .value("Bytes", ColumnType::Bytes)
       .value("Video", ColumnType::Video)
       .value("Image", ColumnType::Image);
 

--- a/scanner/engine/python_kernel.cpp
+++ b/scanner/engine/python_kernel.cpp
@@ -30,7 +30,6 @@ void gen_random(char* s, const int len) {
 PythonKernel::PythonKernel(const KernelConfig &config,
                            const std::string &op_name,
                            const std::string &kernel_code,
-                           const std::string &pickled_config,
                            const bool can_batch,
                            const bool can_stencil)
     : StenciledBatchedKernel(config), config_(config),
@@ -72,7 +71,6 @@ PythonKernel::PythonKernel(const KernelConfig &config,
     // mode on MacOS fails....
     main.attr(kernel_ns_name_.c_str()) = py::dict(
         "kernel_code"_a=py::bytes(kernel_code),
-        "user_config_str"_a=py::bytes(pickled_config),
         "config"_a=cloudpickle.attr("dumps")(config));
 
     std::string pycode = tfm::format(R"(
@@ -278,7 +276,6 @@ void PythonKernel::execute(const StenciledBatchedElements &input_columns,
       send_pipe.attr("send_bytes")(pickled_data);
       py::object recv_data = recv_pipe.attr("recv_bytes")();
       py::tuple out_cols = cloudpickle.attr("loads")(recv_data).cast<py::tuple>();
-
 
       for (i32 j = 0; j < out_cols.size(); ++j) {
         batched_out_cols.push_back(out_cols[j].cast<std::vector<py::object>>());

--- a/scanner/engine/python_kernel.h
+++ b/scanner/engine/python_kernel.h
@@ -10,7 +10,6 @@ class PythonKernel : public StenciledBatchedKernel {
   PythonKernel(const KernelConfig& config,
                const std::string& op_name,
                const std::string& kernel_code,
-               const std::string& pickled_config,
                const bool can_batch,
                const bool con_stencil);
 

--- a/scanner/engine/rpc.proto
+++ b/scanner/engine/rpc.proto
@@ -170,7 +170,6 @@ message PythonKernelRegistration {
   string op_name = 1;
   DeviceType device_type = 2;
   bytes kernel_code = 3;
-  bytes pickled_config = 4;
   int32 batch_size = 5;
 }
 

--- a/scanner/engine/worker.cpp
+++ b/scanner/engine/worker.cpp
@@ -741,6 +741,7 @@ void WorkerImpl::register_op(const proto::OpRegistration* op_registration) {
     col.set_id(i++);
     col.set_name(c.name());
     col.set_type(c.type());
+    col.set_type_name(c.type_name());
     input_columns.push_back(col);
   }
   std::vector<Column> output_columns;
@@ -750,6 +751,7 @@ void WorkerImpl::register_op(const proto::OpRegistration* op_registration) {
     col.set_id(i++);
     col.set_name(c.name());
     col.set_type(c.type());
+    col.set_type_name(c.type_name());
     output_columns.push_back(col);
   }
   bool can_stencil = op_registration->can_stencil();
@@ -773,7 +775,6 @@ void WorkerImpl::register_python_kernel(const proto::PythonKernelRegistration* p
   const std::string& op_name = python_kernel->op_name();
   DeviceType device_type = python_kernel->device_type();
   const std::string& kernel_code = python_kernel->kernel_code();
-  const std::string& pickled_config = python_kernel->pickled_config();
   const int batch_size = python_kernel->batch_size();
 
   // Set all input and output columns to be CPU
@@ -798,9 +799,9 @@ void WorkerImpl::register_python_kernel(const proto::PythonKernelRegistration* p
   }
 
   // Create a kernel builder function
-  auto constructor = [op_name, kernel_code, pickled_config,
+  auto constructor = [op_name, kernel_code,
                       can_batch, can_stencil](const KernelConfig& config) {
-      return new PythonKernel(config, op_name, kernel_code, pickled_config,
+      return new PythonKernel(config, op_name, kernel_code,
                               can_batch, can_stencil);
   };
 
@@ -1137,7 +1138,7 @@ bool WorkerImpl::process_job(const proto::BulkJobParameters* job_params,
       kernel_config.input_columns.push_back(input.column());
       if (input_columns.size() == 0) {
         // We ccan have 0 columns in op info if variadic arguments
-        kernel_config.input_column_types.push_back(ColumnType::Other);
+        kernel_config.input_column_types.push_back(ColumnType::Bytes);
       } else {
         kernel_config.input_column_types.push_back(input_columns[i].type());
       }

--- a/scanner/metadata.proto
+++ b/scanner/metadata.proto
@@ -41,7 +41,7 @@ enum ImageColorSpace {
 }
 
 enum ColumnType {
-  Other = 0;
+  Bytes = 0;
   Video = 1;
   Image = 2;
 }
@@ -57,6 +57,7 @@ message Column {
   int32 id = 1;
   string name = 2;
   ColumnType type = 3;
+  string type_name = 4;
 }
 
 message VideoDescriptor {

--- a/setup.py
+++ b/setup.py
@@ -113,8 +113,8 @@ def main():
        }
 
     REQUIRED_PACKAGES = [
-        # 'protobuf == 3.6.1', 'grpcio == 1.16.0', 'toml >= 0.9.2',
-        # 'numpy >= 1.12.0,<=1.16.0', 'tqdm >= 4.19.5', 'cloudpickle >=0.5.3,<=0.6.1'
+        'protobuf == 3.6.1', 'grpcio == 1.16.0', 'toml >= 0.9.2',
+        'numpy >= 1.12.0,<=1.16.0', 'tqdm >= 4.19.5', 'cloudpickle >=0.5.3,<=0.6.1'
        ]
 
     TEST_PACKAGES = [

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ def main():
     #os.makedirs(PIP_DIR, exist_ok=True)
     #os.makedirs(PIP_DIR + '/scanner', exist_ok=True)
     #os.makedirs(PIP_DIR + '/scanner/stdlib', exist_ok=True)
-    
+
     # Copy python into pip directory
     #shutil.copytree(SCANNERPY_DIR, PIP_DIR + '/scannerpy')
 
@@ -28,7 +28,7 @@ def main():
         EXT = '.so'
     else:
         EXT = '.dylib'
-    
+
     # Copy libraries into pip directory
     LIBRARIES = [
         os.path.join(BUILD_DIR, 'libscanner' + EXT),
@@ -38,8 +38,8 @@ def main():
     for library in LIBRARIES:
         name = os.path.splitext(os.path.basename(library))[0]
         shutil.copyfile(library, os.path.join(PIP_DIR, 'scannerpy', 'lib', name + EXT))
-    
-    
+
+
     def copy_partial_tree(from_dir, to_dir, pattern):
         dest_paths = []
         try:
@@ -50,7 +50,7 @@ def main():
             print(f)
             shutil.copy(f, to_dir)
             dest_paths.append(os.path.join(to_dir, os.path.basename(f)))
-    
+
         # List all directories in from_dir
         for d in [
                 p for p in os.listdir(from_dir)
@@ -60,8 +60,8 @@ def main():
             dest_paths += copy_partial_tree(
                 os.path.join(from_dir, d), os.path.join(to_dir, d), pattern)
         return dest_paths
-    
-    
+
+
     def glob_files(path, prefix=''):
         all_paths = os.listdir(path)
         files = [
@@ -72,8 +72,8 @@ def main():
             files += glob_files(
                 os.path.join(path, d), prefix=os.path.join(prefix, d))
         return files
-    
-    
+
+
     # Copy built protobuf python files
     copy_partial_tree(
         os.path.join(BUILD_DIR, 'scanner'), os.path.join(PIP_DIR, 'scanner'),
@@ -81,7 +81,7 @@ def main():
     copy_partial_tree(
         os.path.join(BUILD_DIR, 'stdlib'),
         os.path.join(PIP_DIR, 'scanner', 'stdlib'), '*.py')
-    
+
     # Copy cmake files
     os.makedirs(os.path.join(PIP_DIR, 'scannerpy', 'cmake'))
     shutil.copy(
@@ -90,9 +90,9 @@ def main():
     copy_partial_tree(
         os.path.join(SCANNER_DIR, 'cmake', 'Modules'),
         os.path.join(PIP_DIR, 'scannerpy', 'cmake', 'Modules'), '*')
-    
+
     cmake_files = glob_files(os.path.join(PIP_DIR, 'scannerpy', 'cmake'), 'cmake')
-    
+
     # Copy scanner headers
     copy_partial_tree(
         os.path.join(SCANNER_DIR, 'scanner'),
@@ -100,38 +100,38 @@ def main():
     copy_partial_tree(
         os.path.join(SCANNER_DIR, 'scanner'),
         os.path.join(PIP_DIR, 'scannerpy', 'include', 'scanner'), '*.inl')
-    
+
     copy_partial_tree(
         os.path.join(BUILD_DIR, 'scanner'),
         os.path.join(PIP_DIR, 'scannerpy', 'include', 'scanner'), '*.h')
-    
+
     include_files = glob_files(
         os.path.join(PIP_DIR, 'scannerpy', 'include'), 'include')
-    
+
     package_data = {
         'scannerpy': ['lib/*.so', 'lib/*' + EXT] + include_files + cmake_files
        }
-    
+
     REQUIRED_PACKAGES = [
-        'protobuf == 3.6.1', 'grpcio == 1.16.0', 'toml >= 0.9.2',
-        'numpy >= 1.12.0,<=1.16.0', 'tqdm >= 4.19.5', 'cloudpickle >=0.5.3,<=0.6.1'
+        # 'protobuf == 3.6.1', 'grpcio == 1.16.0', 'toml >= 0.9.2',
+        # 'numpy >= 1.12.0,<=1.16.0', 'tqdm >= 4.19.5', 'cloudpickle >=0.5.3,<=0.6.1'
        ]
-    
+
     TEST_PACKAGES = [
         'pytest', 'psycopg2-binary == 2.7.6.1', 'testing.postgresql == 1.3.0'
        ]
-    
+
     if platform == 'linux' or platform == 'linux2':
         REQUIRED_PACKAGES.append('python-prctl >= 1.7.0')
-    
+
     # Borrowed from https://github.com/pytorch/pytorch/blob/master/setup.py
     def make_relative_rpath(path):
         if platform == 'linux' or platform == 'linux2':
             return '-Wl,-rpath,$ORIGIN/' + path
         else:
             return '-Wl,-rpath,@loader_path/' + path
-    
-    
+
+
     module1 = Extension(
         'scannerpy._python',
         include_dirs = [ROOT_DIR,
@@ -144,7 +144,7 @@ def main():
         sources = [os.path.join(ROOT_DIR, 'scanner/engine/python.cpp')],
         extra_compile_args=['-std=c++11'],
         extra_link_args=[make_relative_rpath('lib')])
-    
+
     setup(
         name='scannerpy',
         version='0.2.22',

--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,8 @@ def main():
 
     REQUIRED_PACKAGES = [
         'protobuf == 3.6.1', 'grpcio == 1.16.0', 'toml >= 0.9.2',
-        'numpy >= 1.12.0,<=1.16.0', 'tqdm >= 4.19.5', 'cloudpickle >=0.5.3,<=0.6.1'
+        'numpy >= 1.12.0,<=1.16.0', 'tqdm >= 4.19.5', 'cloudpickle >=0.5.3,<=0.6.1',
+        'attrs == 18.2.0'
        ]
 
     TEST_PACKAGES = [

--- a/stdlib/imgproc/histogram_kernel_cpu.cpp
+++ b/stdlib/imgproc/histogram_kernel_cpu.cpp
@@ -49,7 +49,7 @@ class HistogramKernelCPU : public BatchedKernel {
   DeviceHandle device_;
 };
 
-REGISTER_OP(Histogram).frame_input("frame").output("histogram");
+REGISTER_OP(Histogram).frame_input("frame").output("histogram", ColumnType::Bytes, "Histogram");
 
 REGISTER_KERNEL(Histogram, HistogramKernelCPU)
     .device(DeviceType::CPU)

--- a/tests/py_test.py
+++ b/tests/py_test.py
@@ -759,7 +759,7 @@ class TestPyBatch(Kernel):
         pass
 
     def execute(self, frame: Sequence[FrameType]) -> Sequence[bytes]:
-        from scannerpy import protobufs
+
         point = protobufs.Point()
         point.x = 10
         point.y = 5
@@ -791,7 +791,7 @@ class TestPyStencil(Kernel):
         pass
 
     def execute(self, frame: Sequence[FrameType]) -> bytes:
-        from scannerpy import protobufs
+
         assert len(frame) == 2
         point = protobufs.Point()
         point.x = 10
@@ -822,7 +822,7 @@ class TestPyStencilBatch(Kernel):
         pass
 
     def execute(self, frame: Sequence[Sequence[FrameType]]) -> Sequence[bytes]:
-        from scannerpy import protobufs
+
         assert len(frame[0]) == 2
         point = protobufs.Point()
         point.x = 10

--- a/tests/spawn_worker.py
+++ b/tests/spawn_worker.py
@@ -1,4 +1,4 @@
-from scannerpy import ProtobufGenerator, Config, start_worker
+from scannerpy import protobufs, Config, start_worker
 import time
 import grpc
 import sys
@@ -11,7 +11,6 @@ import scanner.types_pb2 as misc_types
 import scannerpy._python as bindings
 
 con = Config(config_path='/tmp/config_test')
-protobufs = ProtobufGenerator(con)
 
 master_address = str(con.master_address) + ':' + str(con.master_port)
 port = int(sys.argv[1])


### PR DESCRIPTION
TODOs
- [ ] Move all readers/writers into types
- [ ] Update all examples
- [ ] Add types to C++ ops

Note that there's a weird hacky thing where cloudpickle won't serialize functions that close over `scannerpy.protobufs`. Not sure why.