### PR TITLE
Fix HEVC inplace indexing

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -402,10 +402,10 @@ elif [[ $INSTALL_ALL == false ]]; then
 
     echo "Optional dependencies: "
     if [[ -z ${WITH_OPENVINO+x} ]] && [[ ${NO_OPENVINO+x} != true ]] && [[ "$OSTYPE" == "linux-gnu" ]]; then
-        echo -n "Do you need support for OpenVino Inference Engine? [y/N]: "
+        echo -n "Do you need support for OpenVINO Inference Engine? [y/N]: "
         read yn
         if [[ $yn != n ]] && [[ $yn != N ]]; then
-            echo -n "Do you have OpenVino Inference Engine 2019 R2.0.1 installed? [y/N]: "
+            echo -n "Do you have OpenVINO Inference Engine 2019 R2.0.1 installed? [y/N]: "
             read yn
             if [[ $yn == y ]] || [[ $yn == Y ]]; then
                 INSTALL_OPENVINO=false
@@ -591,10 +591,10 @@ if [[ $INSTALL_OPENVINO == true ]] && [[ ! -f $BUILD_DIR/openvino.done ]] ; then
     sed -i 's/decline/accept/g' silent.cfg
     sed -i 's/COMPONENTS=DEFAULTS/COMPONENTS=intel-openvino-ie-rt-cpu-ubuntu-xenial__x86_64;intel-openvino-ie-rt-gpu-ubuntu-xenial__x86_64;intel-openvino-ie-sdk-ubuntu-xenial__x86_64;intel-openvino-model-optimizer__x86_64/g' silent.cfg
     sed -i "s!PSET_INSTALL_DIR=/opt/intel!PSET_INSTALL_DIR=$INSTALL_PREFIX/intel!g" silent.cfg
-    ./install.sh --silent silent.cfg || { echo 'Installing OpenVino failed!' ; exit 1; }
+    ./install.sh --silent silent.cfg || { echo 'Installing OpenVINO failed!' ; exit 1; }
     cd .. && rm l_openvino_toolkit_p_2019.2.275.tgz
     touch $BUILD_DIR/openvino.done
-    echo "Done installing OpenVino Inference Engine 2019 R2.0.1"
+    echo "Done installing OpenVINO Inference Engine 2019 R2.0.1"
     #This will be needed by OpenCV
     INTEL_OPENVINO_DIR=$INSTALL_PREFIX/intel/openvino_2019.2.275
     export INTEL_OPENVINO_DIR=$INTEL_OPENVINO_DIR

--- a/deps.sh
+++ b/deps.sh
@@ -1035,5 +1035,5 @@ if [[ $INSTALL_OPENVINO == true ]]; then
     IE_PLUGINS_PATH=$INTEL_OPENVINO_DIR/deployment_tools/inference_engine/lib/intel64
     echo "export LD_LIBRARY_PATH=$HDDL_INSTALL_DIR/lib:$INTEL_OPENVINO_DIR/deployment_tools/inference_engine/external/gna/lib:$INTEL_OPENVINO_DIR/deployment_tools/inference_engine/external/mkltiny_lnx/lib:$INTEL_OPENVINO_DIR/deployment_tools/inference_engine/external/tbb/lib:$IE_PLUGINS_PATH:$LD_LIBRARY_PATH"
     # OpenVINO's Python API
-    echo "export PYTHONPATH=$INTEL_OPENVINO_DIR/python/python$PYTHON_VERSION"
+    echo "export PYTHONPATH=$INTEL_OPENVINO_DIR/python/python$PYTHON_VERSION:\$PYTHONPATH"
 fi

--- a/scanner/engine/column_source.cpp
+++ b/scanner/engine/column_source.cpp
@@ -499,8 +499,9 @@ void ColumnSource::read(const std::vector<ElementArgs>& element_args,
       info = FrameInfo(entry.height, entry.width, entry.channels,
                        entry.frame_type);
       codec_type_= entry.codec_type;
-      if (entry.codec_type == proto::VideoDescriptor::H264) {
-        // Video was encoded using h264
+      if (entry.codec_type == proto::VideoDescriptor::H264 ||
+              entry.codec_type == proto::VideoDescriptor::HEVC) {
+        // Video was encoded using h264 or hevc
         read_video_column(*profiler_, entry, valid_offsets, item_start_row,
                           output_columns[0]);
       } else {

--- a/scanner/engine/ingest.cpp
+++ b/scanner/engine/ingest.cpp
@@ -460,7 +460,22 @@ bool parse_video_inplace(storehouse::StorageBackend* storage,
   video_descriptor.set_channels(3);
   video_descriptor.set_frame_type(FrameType::U8);
   video_descriptor.set_chroma_format(proto::VideoDescriptor::YUV_420);
-  video_descriptor.set_codec_type(proto::VideoDescriptor::H264);
+  std::string video_descriptor_codec_type = index.format();
+  if(video_descriptor_codec_type == "h265" ||
+        video_descriptor_codec_type == "hev1" ||
+        video_descriptor_codec_type == "hevc"){
+    video_descriptor.set_codec_type(proto::VideoDescriptor::HEVC);
+    LOG(INFO) << "Codec Type: HEVC";
+  }
+  else if(video_descriptor_codec_type == "h264" ||
+        video_descriptor_codec_type == "avc1"){
+    video_descriptor.set_codec_type(proto::VideoDescriptor::H264);
+    LOG(INFO) << "Codec Type: H264";
+  }
+  else{
+    error_message = "Unsupported video codec: " + video_descriptor_codec_type;
+    return false;
+  }
 
   video_descriptor.set_data_path(path);
   video_descriptor.set_inplace(true);

--- a/scanner/engine/video_index_entry.cpp
+++ b/scanner/engine/video_index_entry.cpp
@@ -65,7 +65,8 @@ VideoIndexEntry read_video_index(storehouse::StorageBackend* storage,
   index_entry.keyframe_indices = video_meta.keyframe_indices();
   index_entry.sample_offsets = video_meta.sample_offsets();
   index_entry.sample_sizes = video_meta.sample_sizes();
-  if (index_entry.codec_type == proto::VideoDescriptor::H264) {
+  if (index_entry.codec_type == proto::VideoDescriptor::H264 ||
+      index_entry.codec_type == proto::VideoDescriptor::HEVC) {
     index_entry.metadata = video_meta.metadata();
     // Update keyframe positions and byte offsets so that the separately
     // encoded videos seem like they are one


### PR DESCRIPTION
This PR fixes an issue when passing encoded data to the decoder initialization. Previously, encoded data didn't include format information, which was causing errors when indexing HEVC video using Hwang. 

The PR also propagates the use of HEVC descriptor to other places in the code. 

Thanks!